### PR TITLE
do not fail with unfound columns, let AR handle it

### DIFF
--- a/lib/kasket/configuration_mixin.rb
+++ b/lib/kasket/configuration_mixin.rb
@@ -37,7 +37,12 @@ module Kasket
         key = attribute_value_pairs.map do |attribute, value|
           column = columns_hash[attribute.to_s]
           value = nil if value.blank?
-          attribute.to_s + '=' + connection.quote(column.type_cast(value), column).downcase
+          quoted_value = if column
+            connection.quote(column.type_cast(value), column).downcase
+          else
+            value.to_s
+          end
+          attribute.to_s << '=' << quoted_value
         end.join('/')
 
         if key.size > (250 - kasket_key_prefix.size) || key =~ /\s/

--- a/test/configuration_mixin_test.rb
+++ b/test/configuration_mixin_test.rb
@@ -10,6 +10,13 @@ class ConfigurationMixinTest < ActiveSupport::TestCase
       assert_equal expected_cache_key, Post.kasket_key_for(query_attributes)
     end
 
+    should "not fail on unknown columns" do
+      expected_cache_key = "#{Post.kasket_key_prefix}does_not_exist=111"
+      query_attributes   = [ [:does_not_exist, '111'] ]
+
+      assert_equal expected_cache_key, Post.kasket_key_for(query_attributes)
+    end
+
     should "not generate keys longer that 255" do
       very_large_number = (1..999).to_a.join
       query_attributes  = [ [:blog_id, very_large_number] ]


### PR DESCRIPTION
Using a unknown column like `User.first(:conditions => {:ffff => 1})` would trigger an error in kasket and make it look like kasket is broken, instead of just letting AR fail with a nice unknown column error.

@staugaard @zendesk-jcheatham 
