### PR TITLE
Adds exception when trying to remove_from_kasket for an object keyed with multiple attributes

### DIFF
--- a/lib/kasket/write_mixin.rb
+++ b/lib/kasket/write_mixin.rb
@@ -3,6 +3,7 @@ module Kasket
 
     module ClassMethods
       def remove_from_kasket(ids)
+        raise ArgumentError.new("unable to remove cache keyed on multiple attributes") if kasket_indices.any?{|ki| ki.size > 1 }
         Array(ids).each do |id|
           Kasket.cache.delete(kasket_key_for_id(id))
         end


### PR DESCRIPTION
@staugaard @grosser

Would have added a test... but I guess there are no tests at all for this mixin?
### Risks

Low - I believe I've removed all actual usages of this method according to github, this is just a safeguard to prevent future usage (as insisted upon by @grosser).
