### PR TITLE
Fix for Rails 4.2 and type_cast

### DIFF
--- a/test/configuration_mixin_test.rb
+++ b/test/configuration_mixin_test.rb
@@ -18,10 +18,8 @@ describe "configuration mixin" do
     end
 
     it "not generate keys longer that 255" do
-      very_large_number = (1..999).to_a.join
-      query_attributes  = [ [:blog_id, very_large_number] ]
-
-      assert(Post.kasket_key_for(query_attributes).size < 255)
+      Post.stubs(:quoted_value_for_column).returns((1..999).to_a.join.to_s)
+      assert(Post.kasket_key_for([:blog_id, 1]).size < 255)
     end
 
     it "not generate keys with spaces" do


### PR DESCRIPTION
@grosser 

Code was trying to do something smart to avoid limitations of type_cast_for_database which rejects values larger than the column can handle. This does not work with datetime column so going for something simpler and changing the test rather than the code.

### Risks
 - None