### PR TITLE
add expires_in option and random refactors

### DIFF
--- a/kasket.gemspec
+++ b/kasket.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency("bump")
   s.add_development_dependency("minitest")
   s.add_development_dependency("minitest-rg")
+  s.add_development_dependency("timecop")
 
   s.files        = Dir.glob("lib/**/*") + %w(README.rdoc)
 end

--- a/lib/kasket/configuration_mixin.rb
+++ b/lib/kasket/configuration_mixin.rb
@@ -66,8 +66,8 @@ module Kasket
     end
 
     def has_kasket_on(*args)
-      attributes = args.sort! { |x, y| x.to_s <=> y.to_s }
-      if attributes != [:id] && !kasket_indices.include?([:id])
+      attributes = args.sort_by!(&:to_s)
+      if attributes != [:id] && !has_kasket_index_on?([:id])
         has_kasket_on(:id)
       end
 
@@ -79,7 +79,16 @@ module Kasket
       extend ReadMixin unless methods.map(&:to_sym).include?(:find_by_sql_with_kasket)
     end
 
+    def kasket_expires_in(time)
+      @kasket_expires_in = time
+    end
+
+    def _kasket_expires_in
+      @kasket_expires_in
+    end
+
     private
+
     def quoted_value_for_column(value, column)
       if column
         casted_value = if column.respond_to?(:type_cast_for_database)

--- a/lib/kasket/configuration_mixin.rb
+++ b/lib/kasket/configuration_mixin.rb
@@ -79,11 +79,11 @@ module Kasket
       extend ReadMixin unless methods.map(&:to_sym).include?(:find_by_sql_with_kasket)
     end
 
-    def has_kasket_expire_in(time)
-      @kasket_expires_in = time
+    def kasket_expires_in(time)
+      @kasket_ttl = time
     end
 
-    attr_reader :kasket_expires_in
+    attr_reader :kasket_ttl
 
     private
 

--- a/lib/kasket/configuration_mixin.rb
+++ b/lib/kasket/configuration_mixin.rb
@@ -79,13 +79,11 @@ module Kasket
       extend ReadMixin unless methods.map(&:to_sym).include?(:find_by_sql_with_kasket)
     end
 
-    def kasket_expires_in(time)
+    def has_kasket_expire_in(time)
       @kasket_expires_in = time
     end
 
-    def _kasket_expires_in
-      @kasket_expires_in
-    end
+    attr_reader :kasket_expires_in
 
     private
 

--- a/lib/kasket/write_mixin.rb
+++ b/lib/kasket/write_mixin.rb
@@ -29,9 +29,11 @@ module Kasket
         true
       end
 
-      def store_in_kasket
-        if kasket_cacheable? && kasket_key
-          Kasket.cache.write(kasket_key, @attributes.to_h.dup)
+      def store_in_kasket(key = kasket_key)
+        if kasket_cacheable? && key
+          options = { expires_in: self.class._kasket_expires_in } if self.class._kasket_expires_in
+          Kasket.cache.write(key, attributes_before_type_cast.dup, options)
+          key
         end
       end
 

--- a/lib/kasket/write_mixin.rb
+++ b/lib/kasket/write_mixin.rb
@@ -31,7 +31,7 @@ module Kasket
 
       def store_in_kasket(key = kasket_key)
         if kasket_cacheable? && key
-          options = { expires_in: self.class._kasket_expires_in } if self.class._kasket_expires_in
+          options = { expires_in: self.class.kasket_expires_in } if self.class.kasket_expires_in
           Kasket.cache.write(key, attributes_before_type_cast.dup, options)
           key
         end

--- a/lib/kasket/write_mixin.rb
+++ b/lib/kasket/write_mixin.rb
@@ -31,7 +31,7 @@ module Kasket
 
       def store_in_kasket(key = kasket_key)
         if kasket_cacheable? && key
-          options = { expires_in: self.class.kasket_expires_in } if self.class.kasket_expires_in
+          options = { expires_in: self.class.kasket_ttl } if self.class.kasket_ttl
           Kasket.cache.write(key, attributes_before_type_cast.dup, options)
           key
         end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -4,6 +4,7 @@ require 'minitest/rg'
 require 'mocha/setup'
 require 'active_record'
 require 'logger'
+require 'timecop'
 
 ENV['TZ'] = 'UTC'
 ActiveRecord::Base.time_zone_aware_attributes = true

--- a/test/read_mixin_test.rb
+++ b/test/read_mixin_test.rb
@@ -74,9 +74,7 @@ describe Kasket::ReadMixin do
 
         assert_not_equal @record, same_record
       end
-
     end
-
   end
 
   it "support serialized attributes" do
@@ -102,4 +100,14 @@ describe Kasket::ReadMixin do
     end
   end
 
+  it "expires the cache when the expires_in option is set" do
+    Rails.cache.clear
+    old = ExpiringComment.find(1).updated_at
+    ExpiringComment.where(id: 1).update_all(updated_at: Time.now + 10.seconds)
+    ExpiringComment.find(1).updated_at.must_equal old # caching works
+
+    Timecop.travel(Time.now + 6.minutes) do
+      ExpiringComment.find(1).updated_at.wont_equal old # cache expired
+    end
+  end
 end

--- a/test/read_mixin_test.rb
+++ b/test/read_mixin_test.rb
@@ -101,7 +101,6 @@ describe Kasket::ReadMixin do
   end
 
   it "expires the cache when the expires_in option is set" do
-    Rails.cache.clear
     old = ExpiringComment.find(1).updated_at
     ExpiringComment.where(id: 1).update_all(updated_at: Time.now + 10.seconds)
     ExpiringComment.find(1).updated_at.must_equal old # caching works

--- a/test/test_models.rb
+++ b/test/test_models.rb
@@ -47,5 +47,5 @@ class ExpiringComment < ActiveRecord::Base
   self.table_name = 'comments'
 
   has_kasket
-  has_kasket_expire_in 5.minutes
+  kasket_expires_in 5.minutes
 end

--- a/test/test_models.rb
+++ b/test/test_models.rb
@@ -47,5 +47,5 @@ class ExpiringComment < ActiveRecord::Base
   self.table_name = 'comments'
 
   has_kasket
-  kasket_expires_in 5.minutes
+  has_kasket_expire_in 5.minutes
 end

--- a/test/test_models.rb
+++ b/test/test_models.rb
@@ -42,3 +42,10 @@ class Blog < ActiveRecord::Base
   has_many :posts
   has_many :comments, :through => :posts
 end
+
+class ExpiringComment < ActiveRecord::Base
+  self.table_name = 'comments'
+
+  has_kasket
+  kasket_expires_in 5.minutes
+end


### PR DESCRIPTION
- expires_in option
- reuse has_kasket_index_on
- optimize attributes sorting
- reuse store_in_kasket for association writes
- remove key is a string check, added without tests
- fixed store_in_kasket to also use attributes_before_type_cast

/cc @staugaard @grosser @jcheatham 