### PR TITLE
lock mysql

### DIFF
--- a/gemfiles/common.rb
+++ b/gemfiles/common.rb
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "mysql2", "~> 0.3", platforms: :ruby
+gem "mysql2", "~> 0.3.0", platforms: :ruby
 gem "activerecord-jdbcmysql-adapter", "~> 1.2", platforms: :jruby
 gem 'mocha', git: 'https://github.com/zendesk/mocha.git', branch: "eac/alias_method_fix" # https://github.com/freerange/mocha/pull/202
 gem 'byebug', platforms: :ruby


### PR DESCRIPTION
Please install the mysql2 adapter: `gem install activerecord-mysql2-adapter` (can't activate mysql2 (~> 0.3.10), already activated mysql2-0.4.1. 

@pschambacher 

### Risks
 - None