### PR TITLE
Switch to after_commit for cache invalidation, add :write_through option for write-through caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ### Puts a cap on your queries
 A caching layer for ActiveRecord (3.x and 4.x)
 
-Developed and used on http://zendesk.com.
+Developed and used by [Zendesk](http://zendesk.com).
 
 ## Sponsored by Zendesk - Enlightened Customer Support
 
@@ -29,11 +29,23 @@ This will include the required modules into ActiveRecord.
 
 ### Options
 
-By default, Kasket will cache instance collection with a maximum length of 100.
+#### Max Collection Size
+
+By default, Kasket will cache each instance collection with a maximum length of 100.
 You can override this by passing the `:max_collection_size` option to the `Kasket.setup` call:
 
 ```
 Kasket.setup(:max_collection_size => 50)
+```
+
+#### Write-Through Caching
+
+By default, when a model is saved, Kasket will invalidate cache entries by deleting them.
+You can pass ':write_through => true' to the `Kasket.setup` call to get write-through cache
+semantics instead. In this mode, the model will be updated in the cache as well as the database.
+
+```
+Kasket.setup(:write_through => true)
 ```
 
 ## Configuring caching of your models
@@ -65,7 +77,7 @@ and all other ways of expressing lookups on subdomain.
 
 ## Cache expiry
 
-The goal of Kasket is to be as safe as possible to use, so the cache is expired in a number of situations
+The goal of Kasket is to be as safe as possible to use, so the cache is expired in a number of situations:
 * When you save a model instance
 * When your database schema changes
 * When you install a new version of Kasket
@@ -103,7 +115,7 @@ We have only used and tested Kasket with MySQL.
 
 Let us know if you find any.
 
-## Isn't this what Cache Money does?
+## Isn't this what [Cache Money](https://github.com/nkallen/cache-money) does?
 
 Absolutely, but Cache Money does so much more.
 * Cache Money has way more features than what we need.

--- a/kasket.gemspec
+++ b/kasket.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency("minitest")
   s.add_development_dependency("minitest-rg")
   s.add_development_dependency("timecop")
+  s.add_development_dependency("test_after_commit")
 
   s.files        = Dir.glob("lib/**/*") + %w(README.md)
 end

--- a/lib/kasket.rb
+++ b/lib/kasket.rb
@@ -14,7 +14,7 @@ module Kasket
   autoload :SelectManagerMixin,     'kasket/select_manager_mixin'
   autoload :RelationMixin,          'kasket/relation_mixin'
 
-  CONFIGURATION = {:max_collection_size => 100}
+  CONFIGURATION = {:max_collection_size => 100, :write_through => false}
 
   module_function
 
@@ -22,6 +22,7 @@ module Kasket
     return if ActiveRecord::Base.respond_to?(:has_kasket)
 
     CONFIGURATION[:max_collection_size] = options[:max_collection_size] if options[:max_collection_size]
+    CONFIGURATION[:write_through] = options[:write_through] if options[:write_through]
 
     ActiveRecord::Base.extend(Kasket::ConfigurationMixin)
 

--- a/lib/kasket/write_mixin.rb
+++ b/lib/kasket/write_mixin.rb
@@ -58,6 +58,17 @@ module Kasket
         keys
       end
 
+      def update_kasket_entries
+        if Kasket::CONFIGURATION[:write_through]
+          primary_kasket_key = store_in_kasket
+          kasket_keys.each do |key|
+            Kasket.cache.delete(key) if key != primary_kasket_key
+          end
+        else
+          clear_kasket_indices
+        end
+      end
+
       def clear_kasket_indices
         kasket_keys.each do |key|
           Kasket.cache.delete(key)
@@ -84,8 +95,8 @@ module Kasket
         model_class.send(:alias_method, :kasket_cacheable?, :default_kasket_cacheable?)
       end
 
-      model_class.after_save :clear_kasket_indices
-      model_class.after_touch :clear_kasket_indices
+      model_class.after_save :update_kasket_entries
+      model_class.after_touch :update_kasket_entries
       model_class.after_destroy :clear_kasket_indices
 
       class << model_class

--- a/lib/kasket/write_mixin.rb
+++ b/lib/kasket/write_mixin.rb
@@ -75,6 +75,10 @@ module Kasket
         @kasket_keys = nil
       end
 
+      def kasket_after_rollback
+        @kasket_keys = nil
+      end
+
       def clear_kasket_indices
         kasket_keys.each do |key|
           Kasket.cache.delete(key)
@@ -103,6 +107,7 @@ module Kasket
 
       model_class.after_save :kasket_after_save
       model_class.after_commit :kasket_after_commit
+      model_class.after_rollback :kasket_after_rollback
 
       class << model_class
         alias_method_chain :transaction, :kasket_disabled

--- a/lib/kasket/write_mixin.rb
+++ b/lib/kasket/write_mixin.rb
@@ -62,13 +62,9 @@ module Kasket
         @kasket_keys = kasket_keys
       end
 
-      def kasket_after_commit_create
-        kasket_after_commit_update
-      end
-
-      def kasket_after_commit_update
+      def kasket_after_commit
         @kasket_keys ||= kasket_keys
-        if Kasket::CONFIGURATION[:write_through]
+        if persisted? && Kasket::CONFIGURATION[:write_through]
           key = store_in_kasket
           @kasket_keys.delete(key)
         end
@@ -77,10 +73,6 @@ module Kasket
         end
       ensure
         @kasket_keys = nil
-      end
-
-      def kasket_after_commit_destroy
-        clear_kasket_indices
       end
 
       def clear_kasket_indices
@@ -110,9 +102,7 @@ module Kasket
       end
 
       model_class.after_save :kasket_after_save
-      model_class.after_commit :kasket_after_commit_create, :on => :create
-      model_class.after_commit :kasket_after_commit_update, :on => :update
-      model_class.after_commit :kasket_after_commit_destroy, :on => :destroy
+      model_class.after_commit :kasket_after_commit
 
       class << model_class
         alias_method_chain :transaction, :kasket_disabled

--- a/lib/kasket/write_mixin.rb
+++ b/lib/kasket/write_mixin.rb
@@ -40,8 +40,8 @@ module Kasket
       def kasket_keys
         attribute_sets = [attributes.symbolize_keys]
 
-        if changed?
-          old_attributes = Hash[*changes.map {|attribute, values| [attribute, values[0]]}.flatten].symbolize_keys
+        if previous_changes.present?
+          old_attributes = Hash[*previous_changes.map {|attribute, values| [attribute, values[0]]}.flatten].symbolize_keys
           attribute_sets << old_attributes.reverse_merge(attribute_sets[0])
         end
 
@@ -58,25 +58,17 @@ module Kasket
         keys
       end
 
-      def kasket_after_save
-        @kasket_keys = kasket_keys
-      end
-
       def kasket_after_commit
-        @kasket_keys ||= kasket_keys
+        keys = kasket_keys
+
         if persisted? && Kasket::CONFIGURATION[:write_through]
           key = store_in_kasket
-          @kasket_keys.delete(key)
+          keys.delete(key)
         end
-        @kasket_keys.each do |key|
+
+        keys.each do |key|
           Kasket.cache.delete(key)
         end
-      ensure
-        @kasket_keys = nil
-      end
-
-      def kasket_after_rollback
-        @kasket_keys = nil
       end
 
       def clear_kasket_indices
@@ -105,9 +97,11 @@ module Kasket
         model_class.send(:alias_method, :kasket_cacheable?, :default_kasket_cacheable?)
       end
 
-      model_class.after_save :kasket_after_save
       model_class.after_commit :kasket_after_commit
-      model_class.after_rollback :kasket_after_rollback
+
+      if ActiveRecord::VERSION::MAJOR == 3 || (ActiveRecord::VERSION::MAJOR == 4 && ActiveRecord::VERSION::MINOR == 0)
+        model_class.after_touch :kasket_after_commit
+      end
 
       class << model_class
         alias_method_chain :transaction, :kasket_disabled

--- a/test/dirty_test.rb
+++ b/test/dirty_test.rb
@@ -19,9 +19,7 @@ describe "dirty" do
   end
 
   it "clears the indices when touch is called" do
-    assert_cleared do |p|
-      p.touch
-    end
+    assert_cleared { |p| p.touch }
   end
 
   it "clear the indices when update_column is called" do

--- a/test/dirty_test.rb
+++ b/test/dirty_test.rb
@@ -18,8 +18,13 @@ describe "dirty" do
     assert_cleared { |p| p.make_dirty! }
   end
 
-  it "clear the indices when a touch is called" do
-    assert_cleared { |p| p.touch }
+  it "clears the indices when touch is called" do
+    assert_cleared do |p|
+      p.touch
+
+      # Kludge - in test, after_commit callback runs too late.
+      p.save if ActiveRecord::VERSION::MAJOR == 3
+    end
   end
 
   it "clear the indices when update_column is called" do

--- a/test/dirty_test.rb
+++ b/test/dirty_test.rb
@@ -21,9 +21,6 @@ describe "dirty" do
   it "clears the indices when touch is called" do
     assert_cleared do |p|
       p.touch
-
-      # Kludge - in test, after_commit callback runs too late.
-      p.save if ActiveRecord::VERSION::MAJOR == 3
     end
   end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -5,15 +5,22 @@ require 'mocha/setup'
 require 'active_record'
 require 'logger'
 require 'timecop'
+require 'test_after_commit'
 
 ENV['TZ'] = 'UTC'
 ActiveRecord::Base.time_zone_aware_attributes = true
 ActiveRecord::Base.logger = Logger.new(StringIO.new)
 
+if ActiveRecord::Base.respond_to?(:raise_in_transactional_callbacks)
+  ActiveRecord::Base.raise_in_transactional_callbacks = true
+end
+
 require 'active_record/fixtures'
 require 'kasket'
 
 Kasket.setup
+
+TestAfterCommit.enabled = true
 
 ActiveSupport.test_order = :random if ActiveSupport.respond_to?(:test_order=)
 

--- a/test/test_models.rb
+++ b/test/test_models.rb
@@ -1,9 +1,11 @@
 ActiveRecord::Base.configurations = YAML::load(IO.read(File.expand_path("database.yml", File.dirname(__FILE__))))
 
-conf = ActiveRecord::Base.configurations['test']
-`echo "drop DATABASE if exists #{conf['database']}" | mysql --user=#{conf['username']}`
-`echo "create DATABASE #{conf['database']} DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci" | mysql --user=#{conf['username']}`
+config = ActiveRecord::Base.configurations['test']
+
+ActiveRecord::Base.establish_connection(config.merge('database' => nil))
+ActiveRecord::Base.connection.recreate_database(config['database'], config)
 ActiveRecord::Base.establish_connection(:test)
+
 load(File.dirname(__FILE__) + "/schema.rb")
 
 class Comment < ActiveRecord::Base


### PR DESCRIPTION
When a model is updated or deleted, Kasket deletes all cache entries associated with it.

In some situations, this can lead to a race condition that results in stale data remaining in the cache.

Example: @steved figured out that Process X might be clearing the cache entries associated with a model, but because this happens in an `after_save` callback, Process Y might query the database, get the old contents of the model, since it can't see data that is an open transaction that hasn't been committed yet, and populate the cache with that stale data.

Solution: When Kasket was first written, the `after_commit` callback didn't exist. Now we can use it, and be assured that the database actually is reporting the data that we just wrote. Now we can delete the cache and be pretty assured that anyone else populating the cache will not miss our update.

To further reduce the possibility of race conditions, this PR adds write-through caching as an option for Kasket. When `Kasket.setup` is called with `:write_through => true`, Kasket will update the main cache entry (the one returned by the `kasket_key` method) instead of deleting it. (The rest of the indices are harder to update correctly, so we continue to delete them.)

@grosser @pschambacher @steved @pdeuter @jcheatham @morten @staugaard 