### PR TITLE
Update/clear cache entries by hooking into committed!

### DIFF
--- a/lib/kasket/write_mixin.rb
+++ b/lib/kasket/write_mixin.rb
@@ -92,21 +92,9 @@ module Kasket
         # This is here to force committed! to be invoked.
       end
 
-      if ActiveRecord::VERSION::MAJOR > 4
-        def committed!(should_run_callbacks: true)
-          kasket_after_commit if should_run_callbacks && persisted? || destroyed?
-          super
-        end
-      elsif ActiveRecord::VERSION::MAJOR == 4 && ActiveRecord::VERSION::MINOR >= 2
-        def committed!(should_run_callbacks = true)
-          kasket_after_commit if should_run_callbacks && persisted? || destroyed?
-          super
-        end
-      else
-        def committed!
-          kasket_after_commit if persisted? || destroyed?
-          super
-        end
+      def committed!(*)
+        kasket_after_commit if persisted? || destroyed?
+        super
       end
     end
 

--- a/lib/kasket/write_mixin.rb
+++ b/lib/kasket/write_mixin.rb
@@ -87,6 +87,27 @@ module Kasket
         clear_kasket_indices
         result
       end
+
+      def kasket_after_commit_dummy
+        # This is here to force committed! to be invoked.
+      end
+
+      if ActiveRecord::VERSION::MAJOR > 4
+        def committed!(should_run_callbacks: true)
+          kasket_after_commit if should_run_callbacks && persisted? || destroyed?
+          super
+        end
+      elsif ActiveRecord::VERSION::MAJOR == 4 && ActiveRecord::VERSION::MINOR >= 2
+        def committed!(should_run_callbacks = true)
+          kasket_after_commit if should_run_callbacks && persisted? || destroyed?
+          super
+        end
+      else
+        def committed!
+          kasket_after_commit if persisted? || destroyed?
+          super
+        end
+      end
     end
 
     def self.included(model_class)
@@ -97,7 +118,7 @@ module Kasket
         model_class.send(:alias_method, :kasket_cacheable?, :default_kasket_cacheable?)
       end
 
-      model_class.after_commit :kasket_after_commit
+      model_class.after_commit :kasket_after_commit_dummy
 
       if ActiveRecord::VERSION::MAJOR == 3 || (ActiveRecord::VERSION::MAJOR == 4 && ActiveRecord::VERSION::MINOR == 0)
         model_class.after_touch :kasket_after_commit


### PR DESCRIPTION
Using an `after_commit` hook to clear/update the Kasket cache entries leaves open the possibility of other `after_commit` hooks interfering by raising exceptions.

In Rails 3.x, another `after_commit` hook might raise an exception and cause the `kasket_after_commit` hook not to run, and the exception is swallowed silently. In Rails 4.x, raising on transactional callbacks is an option but still could possibly leave behind stale cache entries.

There is also the possibility of other `after_commit` hooks executing before the `kasket_after_commit` hook, and reading stale data out of the cache since it hasn't been updated yet.

This attempts to address that by hooking directly into the `committed!` method in ActiveRecord which invokes the `after_commit` callbacks. This ensures that the `kasket_after_commit` code runs first and that it runs even if one of the other `after_commit` callbacks raises an exception.

Unfortunately, this method has changed signatures twice from Rails 3.2 to Rails 5, so we need to override it in a version-dependent way.

Also unfortunate: Unless there is an `after_commit` hook registered, `committed!` doesn't run in Rails 4.2, so we have to have a dummy `after_commit` hook.

@steved 