### PR TITLE
Prevent stale cache reads between after_save and after_commit

### DIFF
--- a/lib/kasket.rb
+++ b/lib/kasket.rb
@@ -13,6 +13,7 @@ module Kasket
   autoload :Visitor,                'kasket/visitor'
   autoload :SelectManagerMixin,     'kasket/select_manager_mixin'
   autoload :RelationMixin,          'kasket/relation_mixin'
+  autoload :Cache,                  'kasket/cache'
 
   CONFIGURATION = {:max_collection_size => 100, :write_through => false}
 
@@ -33,10 +34,10 @@ module Kasket
   end
 
   def self.cache_store=(options)
-    @cache_store = ActiveSupport::Cache.lookup_store(options)
+    @cache_store = Cache.new(ActiveSupport::Cache.lookup_store(options))
   end
 
   def self.cache
-    @cache_store ||= Rails.cache
+    @cache_store ||= Cache.new(Rails.cache)
   end
 end

--- a/lib/kasket/cache.rb
+++ b/lib/kasket/cache.rb
@@ -1,0 +1,48 @@
+require 'set'
+
+module Kasket
+  class Cache
+    def initialize(cache_store)
+      @cache_store = cache_store
+    end
+
+    def clear
+      @cache_store.clear
+    end
+
+    def read(key)
+      @cache_store.read(key) unless blacklisted?(key)
+    end
+
+    def read_multi(*args)
+      args = args - blacklist.to_a
+      @cache_store.read_multi(*args)
+    end
+
+    def write(key, value, options = {})
+      @cache_store.write(key, value, options) unless blacklisted?(key)
+    end
+
+    def delete(key)
+      @cache_store.delete(key) unless blacklisted?(key)
+    end
+
+    def clear_blacklist
+      blacklist.clear
+    end
+
+    def add_to_blacklist(keys)
+      blacklist.merge(keys)
+    end
+
+    private
+
+    def blacklist
+      Thread.current['kasket_blacklist'] ||= Set.new
+    end
+
+    def blacklisted?(key)
+      blacklist.include?(key)
+    end
+  end
+end


### PR DESCRIPTION
Another wrinkle that resulted from moving Kasket's cache clearing from `after_save` to `after_commit`: Code that runs between `after_save` and `after_commit` may query for the same objects that have just been saved.

Since `after_commit` hooks haven't run yet, the Kasket cache has not been cleared or updated, so the querying code will be returned a stale object out of Kasket. The querying code could get a good current read by querying the database, but it doesn't because the (stale) Kasket cached entry is still available.

The solution proposed here is a thread-local blacklist of keys that should not be read out of the Kasket cache. We add an `after_save` hook which adds all of the saved object's Kasket keys to the blacklist. In `after_commit` or `after_rollback`, we clear the blacklist.

Any call to `Kasket.cache.read`, `Kasket.cache.read_multi`, etc. regarding a blacklisted key will act as if it's not there, e.g. `Kasket.cache.read` will return `nil`.

This gets a little complicated; one alternative would be to turn off all Kasket caching between the `after_save` and `after_commit` hooks.

/cc @steved @grosser @zendesk/sustaining 

