### PR TITLE
Prevent stale cache reads between after_save and after_commit, Take Two

### DIFF
--- a/lib/kasket.rb
+++ b/lib/kasket.rb
@@ -40,16 +40,18 @@ module Kasket
     @cache_store ||= Rails.cache
   end
 
+  # Keys are the records being saved.
+  # Values are either the saved record, or nil if the record has been destroyed.
   def self.pending_records
-    Thread.current['kasket_pending_records']
+    Thread.current[:kasket_pending_records]
   end
 
-  def self.add_pending_record(key, value)
-    Thread.current['kasket_pending_records'] ||= {}
-    Thread.current['kasket_pending_records'][key] = value
+  def self.add_pending_record(record, destroyed = false)
+    Thread.current[:kasket_pending_records] ||= {}
+    Thread.current[:kasket_pending_records][record] = destroyed ? nil : record
   end
 
   def self.clear_pending_records
-    Thread.current['kasket_pending_records'] = nil
+    Thread.current[:kasket_pending_records] = nil
   end
 end

--- a/lib/kasket.rb
+++ b/lib/kasket.rb
@@ -39,4 +39,17 @@ module Kasket
   def self.cache
     @cache_store ||= Rails.cache
   end
+
+  def self.pending_map
+    Thread.current['kasket_pending_map']
+  end
+
+  def self.add_pending_record(record)
+    Thread.current['kasket_pending_map'] ||= {}
+    Thread.current['kasket_pending_map'][record] = record
+  end
+
+  def self.clear_pending_records
+    Thread.current['kasket_pending_map'] = nil
+  end
 end

--- a/lib/kasket.rb
+++ b/lib/kasket.rb
@@ -40,16 +40,16 @@ module Kasket
     @cache_store ||= Rails.cache
   end
 
-  def self.pending_map
-    Thread.current['kasket_pending_map']
+  def self.pending_records
+    Thread.current['kasket_pending_records']
   end
 
-  def self.add_pending_record(record)
-    Thread.current['kasket_pending_map'] ||= {}
-    Thread.current['kasket_pending_map'][record] = record
+  def self.add_pending_record(key, value)
+    Thread.current['kasket_pending_records'] ||= {}
+    Thread.current['kasket_pending_records'][key] = value
   end
 
   def self.clear_pending_records
-    Thread.current['kasket_pending_map'] = nil
+    Thread.current['kasket_pending_records'] = nil
   end
 end

--- a/lib/kasket/configuration_mixin.rb
+++ b/lib/kasket/configuration_mixin.rb
@@ -6,15 +6,15 @@ module Kasket
   module ConfigurationMixin
 
     def without_kasket(&block)
-      old_value = Thread.current['kasket_disabled'] || false
-      Thread.current['kasket_disabled'] = true
+      old_value = Thread.current[:kasket_disabled] || false
+      Thread.current[:kasket_disabled] = true
       yield
     ensure
-      Thread.current['kasket_disabled'] = old_value
+      Thread.current[:kasket_disabled] = old_value
     end
 
     def use_kasket?
-      !Thread.current['kasket_disabled']
+      !Thread.current[:kasket_disabled]
     end
 
     def kasket_parser

--- a/lib/kasket/read_mixin.rb
+++ b/lib/kasket/read_mixin.rb
@@ -24,9 +24,9 @@ module Kasket
         else
           if value = Kasket.cache.read(query[:key])
             if value.is_a?(Array)
-              find_by_sql_with_kasket_on_id_array(value)
+              filter_pending_records(find_by_sql_with_kasket_on_id_array(value))
             else
-              Array.wrap(value).collect { |record| instantiate(record.dup) }
+              filter_pending_records(Array.wrap(value).collect { |record| instantiate(record.dup) })
             end
           else
             store_in_kasket(query[:key], find_by_sql_without_kasket(*args))
@@ -48,6 +48,14 @@ module Kasket
     end
 
     protected
+
+    def filter_pending_records(records)
+      if pending_map = Kasket.pending_map
+        records.map { |record| pending_map[record] || record }
+      else
+        records
+      end
+    end
 
     def missing_records_from_db(missing_keys)
       return {} if missing_keys.empty?

--- a/lib/kasket/read_mixin.rb
+++ b/lib/kasket/read_mixin.rb
@@ -50,8 +50,8 @@ module Kasket
     protected
 
     def filter_pending_records(records)
-      if pending_map = Kasket.pending_map
-        records.map { |record| pending_map[record] || record }
+      if pending_records = Kasket.pending_records
+        records.map { |record| pending_records.fetch(record, record) }.compact
       else
         records
       end

--- a/lib/kasket/write_mixin.rb
+++ b/lib/kasket/write_mixin.rb
@@ -1,5 +1,3 @@
-require 'set'
-
 module Kasket
   module WriteMixin
 

--- a/lib/kasket/write_mixin.rb
+++ b/lib/kasket/write_mixin.rb
@@ -1,3 +1,5 @@
+require 'set'
+
 module Kasket
   module WriteMixin
 
@@ -92,8 +94,18 @@ module Kasket
         # This is here to force committed! to be invoked.
       end
 
+      def kasket_after_save
+        Kasket.add_pending_record(self)
+      end
+
       def committed!(*)
+        Kasket.clear_pending_records
         kasket_after_commit if persisted? || destroyed?
+        super
+      end
+
+      def rolledback!(*)
+        Kasket.clear_pending_records
         super
       end
     end
@@ -106,6 +118,7 @@ module Kasket
         model_class.send(:alias_method, :kasket_cacheable?, :default_kasket_cacheable?)
       end
 
+      model_class.after_save :kasket_after_save
       model_class.after_commit :kasket_after_commit_dummy
 
       if ActiveRecord::VERSION::MAJOR == 3 || (ActiveRecord::VERSION::MAJOR == 4 && ActiveRecord::VERSION::MINOR == 0)

--- a/lib/kasket/write_mixin.rb
+++ b/lib/kasket/write_mixin.rb
@@ -95,7 +95,11 @@ module Kasket
       end
 
       def kasket_after_save
-        Kasket.add_pending_record(self)
+        Kasket.add_pending_record(self, self)
+      end
+
+      def kasket_after_destroy
+        Kasket.add_pending_record(self, nil)
       end
 
       def committed!(*)
@@ -119,6 +123,7 @@ module Kasket
       end
 
       model_class.after_save :kasket_after_save
+      model_class.after_destroy :kasket_after_destroy
       model_class.after_commit :kasket_after_commit_dummy
 
       if ActiveRecord::VERSION::MAJOR == 3 || (ActiveRecord::VERSION::MAJOR == 4 && ActiveRecord::VERSION::MINOR == 0)

--- a/lib/kasket/write_mixin.rb
+++ b/lib/kasket/write_mixin.rb
@@ -93,11 +93,11 @@ module Kasket
       end
 
       def kasket_after_save
-        Kasket.add_pending_record(self, self)
+        Kasket.add_pending_record(self)
       end
 
       def kasket_after_destroy
-        Kasket.add_pending_record(self, nil)
+        Kasket.add_pending_record(self, destroyed = true)
       end
 
       def committed!(*)

--- a/test/read_mixin_test.rb
+++ b/test/read_mixin_test.rb
@@ -110,7 +110,7 @@ describe Kasket::ReadMixin do
     end
   end
 
-  describe "pending saved records" do
+  describe "pending saved records in a transaction" do
     before do
       @post = Post.find(1)
       assert_not_nil Kasket.cache.read(@post.kasket_key)
@@ -125,6 +125,18 @@ describe Kasket::ReadMixin do
         assert_equal @post.title, Post.where(id: @post.id).first.title
         assert_equal @post.title, Post.all.detect { |x| x.id == @post.id }.title
         assert_equal @post.title, Post.find_by_sql("SELECT * FROM `posts` WHERE id = 1").first.title
+      end
+    end
+
+    it "returns nothing if object destroyed" do
+      ActiveRecord::Base.transaction do
+        @post.destroy
+        assert_raises ActiveRecord::RecordNotFound do
+          Post.find(@post.id)
+        end
+        assert_equal [], Post.where(id: @post.id)
+        assert_nil Post.all.detect { |x| x.id == @post.id }
+        assert_equal [], Post.find_by_sql("SELECT * FROM `posts` WHERE id = 1")
       end
     end
   end

--- a/test/read_mixin_test.rb
+++ b/test/read_mixin_test.rb
@@ -109,4 +109,23 @@ describe Kasket::ReadMixin do
       ExpiringComment.find(1).updated_at.wont_equal old # cache expired
     end
   end
+
+  describe "pending saved records" do
+    before do
+      @post = Post.find(1)
+      assert_not_nil Kasket.cache.read(@post.kasket_key)
+    end
+
+    it "returns saved version" do
+      ActiveRecord::Base.transaction do
+        @post.title = "new_title"
+        @post.save
+
+        assert_equal @post.title, Post.find(@post.id).title
+        assert_equal @post.title, Post.where(id: @post.id).first.title
+        assert_equal @post.title, Post.all.detect { |x| x.id == @post.id }.title
+        assert_equal @post.title, Post.find_by_sql("SELECT * FROM `posts` WHERE id = 1").first.title
+      end
+    end
+  end
 end


### PR DESCRIPTION
This is a new approach to solving the problem in https://github.com/zendesk/kasket/pull/30

After an object has been saved, but before it has been committed, the thread that saved the object might query it again.

If it does, it currently could read the version in the Kasket cache, which is not yet updated or deleted since we've moved the cache invalidation behavior from `after_save` to `after_commit`.

This fixes that problem by keeping a thread-local hash map of objects that have been saved but not committed by the thread. We filter the results of Kasket cache reads to substitute the pending saved object for the stale cached object. This way, the calling thread will see the same view of data in the cache as it does in the database. When we commit or rollback, we can clear the pending records hash.

Note: Kasket disables itself for the current thread when `transaction` is invoked on a Kasket-enabled model. It doesn't, however, disable itself if a transaction is started on a non-Kasket model, or using `ActiveRecord::Base.transaction`. Yet another solution would be to disable Kasket more globally when any AR transaction is in progress, but that would increase cache miss rates.

/cc @zendesk/archer @zendesk/sustaining @staugaard @steved @grosser 
