### PR TITLE
Fix visitor for Rails 4.2+ and nil values

### DIFF
--- a/lib/kasket/visitor.rb
+++ b/lib/kasket/visitor.rb
@@ -125,7 +125,7 @@ module Kasket
     end
 
     def visit_Arel_Nodes_Casted(node, *_)
-      quoted(node.val)
+      quoted(node.val) unless node.val.nil?
     end
 
     def quoted(node)

--- a/test/visitor_test.rb
+++ b/test/visitor_test.rb
@@ -20,6 +20,17 @@ describe Kasket::Visitor do
     assert_equal expected, Post.where(:id => 1).to_kasket_query
   end
 
+  it "builds with nil values" do
+    expected = {
+      :attributes=>[[:deleted_at, nil], [:id, "1"]],
+      :from=>"posts",
+      :index=>[:deleted_at, :id],
+      :key=>"#{Post.kasket_key_prefix}deleted_at=/id=1"
+    }
+
+    assert_equal expected, Post.where(:id => 1, deleted_at: nil).to_kasket_query
+  end
+
   it "build from Nori::StringWithAttributes" do
     expected = {
       :attributes=>[[:id, "1"]],


### PR DESCRIPTION
/cc @zendesk/classic-upgrade 

Until Rails 4.2, `quoted` would return `nil` when passed `nil`.
With 4.2 and up, it started returning `"NULL"`. This is leading so inconsistencies between read and write leading to invalid reads and bad key invalidation.

The test I added fails with Rails 4.2 and 5.0 without the lib change.