### PR TITLE
fix where queries not being cached because they are sent with the def…

### DIFF
--- a/lib/kasket/visitor.rb
+++ b/lib/kasket/visitor.rb
@@ -14,6 +14,8 @@ module Kasket
       super
     end
 
+    private
+
     def last_column=(col)
       Thread.current[:arel_visitors_to_sql_last_column] = col
     end
@@ -30,7 +32,7 @@ module Kasket
       return :unsupported if node.with
       return :unsupported if node.offset
       return :unsupported if node.lock
-      return :unsupported if node.orders.any?
+      return :unsupported if ordered?(node)
       return :unsupported if node.cores.size != 1
 
       query = visit_Arel_Nodes_SelectCore(node.cores[0])
@@ -143,6 +145,11 @@ module Kasket
 
     def quoted(node)
       @model_class.connection.quote(node)
+    end
+
+    # any non `id asc` ordering
+    def ordered?(node)
+      !node.orders.all? { |o| o.is_a?(Arel::Nodes::Ascending) && o.expr.name == "id" }
     end
 
     alias_method :visit_String, :literal

--- a/test/read_mixin_test.rb
+++ b/test/read_mixin_test.rb
@@ -123,13 +123,19 @@ describe Kasket::ReadMixin do
     it "returns saved version" do
       ActiveRecord::Base.transaction do
         @post.title = "new_title"
-        @post.save
+        @post.save!
 
         assert_equal @post.title, Post.find(@post.id).title
         assert_equal @post.title, Post.where(id: @post.id).first.title
         assert_equal @post.title, Post.all.detect { |x| x.id == @post.id }.title
         assert_equal @post.title, Post.find_by_sql("SELECT * FROM `posts` WHERE id = 1").first.title
       end
+    end
+
+    it "finds cached when searching by column" do
+      Post.where(title: 'no_comments').first.title.must_equal 'no_comments'
+      Post.expects(:find_by_sql_without_kasket).never
+      Post.where(title: 'no_comments').first.title.must_equal 'no_comments'
     end
 
     it "returns nothing if object destroyed" do


### PR DESCRIPTION
…ault id asc ordering

@zendesk/classic-upgrade 

test passes on rails 3 and fails on rails 4+ ... so hopefully some perf gains as well :)