### PR TITLE
reduce calls to connection and respond_to ... they are not free

### DIFF
--- a/lib/kasket/visitor.rb
+++ b/lib/kasket/visitor.rb
@@ -159,6 +159,7 @@ module Kasket
     alias_method :visit_String, :literal
     alias_method :visit_Fixnum, :literal
     alias_method :visit_Integer, :literal
+    alias_method :visit_Bignum, :literal
     alias_method :visit_Arel_Nodes_SqlLiteral, :literal
   end
 end

--- a/test/configuration_mixin_test.rb
+++ b/test/configuration_mixin_test.rb
@@ -19,7 +19,7 @@ describe "configuration mixin" do
     end
 
     it "not generate keys longer that 255" do
-      Post.stubs(:quoted_value_for_column).returns((1..999).to_a.join.to_s)
+      Post.stubs(:kasket_quoted_value_for_column).returns((1..999).to_a.join.to_s)
       assert(Post.kasket_key_for([:blog_id, 1]).size < 255)
     end
 

--- a/test/read_mixin_test.rb
+++ b/test/read_mixin_test.rb
@@ -9,7 +9,7 @@ describe Kasket::ReadMixin do
       if ActiveRecord::VERSION::STRING >= '4.2.0'
         @post_database_result = {
           'id' => 1, 'title' => 'Hello', "author_id" => nil, "blog_id" => nil, "poly_id" => nil,
-          "poly_type" => nil, "created_at" => nil, "updated_at" => nil
+          "poly_type" => nil, "created_at" => nil, "updated_at" => nil, "big_id" => nil
         }
         @comment_database_result = [
           { 'id' => 1, 'body' => 'Hello', "post_id" => nil, "created_at" => nil, "updated_at" => nil, "public" => nil },

--- a/test/schema.rb
+++ b/test/schema.rb
@@ -19,6 +19,7 @@ ActiveRecord::Schema.define do
       t.integer  'author_id'
       t.integer  'blog_id'
       t.integer  'poly_id'
+      t.integer  'big_id', limit: 8
       t.string   'poly_type'
       t.datetime 'created_at'
       t.datetime 'updated_at'

--- a/test/visitor_test.rb
+++ b/test/visitor_test.rb
@@ -21,6 +21,11 @@ describe Kasket::Visitor do
     assert_equal expected, Post.where(id: 1).to_kasket_query
   end
 
+  it "builds select Bignum" do
+    num = 9223372036854775807
+    Post.where(big_id: num).to_kasket_query.fetch(:attributes).must_equal([[:big_id, num.to_s]])
+  end
+
   it "builds with nil values" do
     expected = {
       attributes: [[:deleted_at, nil], [:id, "1"]],


### PR DESCRIPTION
flamgraphing stuff and found that kasket chews up some ms in this method ... easy to fix ...
also putting the method into a namespace to avoid confusion

@zendesk/zendesk-rails-upgraders 

<img width="125" alt="screen shot 2017-10-17 at 7 02 57 pm" src="https://user-images.githubusercontent.com/11367/31678270-ece1db82-b36d-11e7-9f63-e1a7ba4a77ff.png">
