### PR TITLE
fix Bignum no longer being visitable

### DIFF
--- a/lib/kasket/visitor.rb
+++ b/lib/kasket/visitor.rb
@@ -159,6 +159,7 @@ module Kasket
     alias_method :visit_String, :literal
     alias_method :visit_Fixnum, :literal
     alias_method :visit_Integer, :literal
+    alias_method :visit_Bignum, :literal
     alias_method :visit_Arel_Nodes_SqlLiteral, :literal
   end
 end

--- a/test/read_mixin_test.rb
+++ b/test/read_mixin_test.rb
@@ -9,7 +9,7 @@ describe Kasket::ReadMixin do
       if ActiveRecord::VERSION::STRING >= '4.2.0'
         @post_database_result = {
           'id' => 1, 'title' => 'Hello', "author_id" => nil, "blog_id" => nil, "poly_id" => nil,
-          "poly_type" => nil, "created_at" => nil, "updated_at" => nil
+          "poly_type" => nil, "created_at" => nil, "updated_at" => nil, "big_id" => nil
         }
         @comment_database_result = [
           { 'id' => 1, 'body' => 'Hello', "post_id" => nil, "created_at" => nil, "updated_at" => nil, "public" => nil },

--- a/test/schema.rb
+++ b/test/schema.rb
@@ -19,6 +19,7 @@ ActiveRecord::Schema.define do
       t.integer  'author_id'
       t.integer  'blog_id'
       t.integer  'poly_id'
+      t.integer  'big_id', limit: 8
       t.string   'poly_type'
       t.datetime 'created_at'
       t.datetime 'updated_at'

--- a/test/visitor_test.rb
+++ b/test/visitor_test.rb
@@ -21,6 +21,11 @@ describe Kasket::Visitor do
     assert_equal expected, Post.where(id: 1).to_kasket_query
   end
 
+  it "builds select Bignum" do
+    num = 9223372036854775807
+    Post.where(big_id: num).to_kasket_query.fetch(:attributes).must_equal([[:big_id, num.to_s]])
+  end
+
   it "builds with nil values" do
     expected = {
       attributes: [[:deleted_at, nil], [:id, "1"]],


### PR DESCRIPTION
test sadly does not fail without it, but tried this patch in classic and it solves the issue :(

```
TypeError: Cannot visit Bignum
    vendor/bundle/ruby/2.2.0/gems/arel-3.0.3/lib/arel/visitors/visitor.rb:25:in `rescue in visit'
```

@pschambacher 
@bquorning worked in v4.4.5 and is now broken on master ... idk how to reproduce