### PR TITLE
store actual records to avoid deserialization overhead

### DIFF
--- a/lib/kasket/read_mixin.rb
+++ b/lib/kasket/read_mixin.rb
@@ -31,7 +31,7 @@ module Kasket
             if value.is_a?(Array)
               filter_pending_records(find_by_sql_with_kasket_on_id_array(value))
             else
-              filter_pending_records(Array.wrap(value).collect { |record| instantiate(record.dup) })
+              filter_pending_records(Array.wrap(value))
             end
           else
             store_in_kasket(query[:key], find_by_sql_without_kasket(*args))
@@ -45,8 +45,7 @@ module Kasket
     def find_by_sql_with_kasket_on_id_array(keys)
       key_attributes_map = Kasket.cache.read_multi(*keys)
 
-      found_keys, missing_keys = keys.partition {|k| key_attributes_map[k] }
-      found_keys.each {|k| key_attributes_map[k] = instantiate(key_attributes_map[k].dup) }
+      missing_keys = keys - key_attributes_map.keys
       key_attributes_map.merge!(missing_records_from_db(missing_keys))
 
       key_attributes_map.values.compact

--- a/lib/kasket/write_mixin.rb
+++ b/lib/kasket/write_mixin.rb
@@ -32,7 +32,7 @@ module Kasket
       def store_in_kasket(key = kasket_key)
         if kasket_cacheable? && key
           options = { expires_in: self.class.kasket_ttl } if self.class.kasket_ttl
-          Kasket.cache.write(key, attributes_before_type_cast.dup, options)
+          Kasket.cache.write(key, self, options)
           key
         end
       end

--- a/test/cache_expiry_test.rb
+++ b/test/cache_expiry_test.rb
@@ -86,12 +86,12 @@ describe "cache expiry" do
       it "is updated in cache when updated" do
         @post.title = "new_title"
         @post.save!
-        assert_equal @post.attributes, Kasket.cache.read(@post.kasket_key)
+        assert_equal @post, Kasket.cache.read(@post.kasket_key)
       end
 
       it "is updated in cache when touched" do
         @post.touch
-        assert_equal @post.attributes, Kasket.cache.read(@post.kasket_key)
+        assert_equal @post, Kasket.cache.read(@post.kasket_key)
       end
 
       it "writes id key and clears indices for instance when updated" do


### PR DESCRIPTION
initialization takes about as long as fetching the records itself

kinda risky since we might cache instance variables by accident ... but seems alright ... comes straight from AR and is not yet modified ...

before: 3ms/record
after: 1.5ms/record
... which gets interesting when loading lots of records

@staugaard @pschambacher
/cc @zendesk/zendesk-rails-upgraders 