### PR TITLE
Configuration for default TTLs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ rvm:
   - 2.2.7
   - 2.3.4
   - 2.4.2
-  - jruby
+  - jruby-9.1.9.0
 
 gemfile:
   - gemfiles/rails3.2.gemfile
@@ -25,9 +25,9 @@ matrix:
       gemfile: gemfiles/rails3.2.gemfile
     - rvm: 2.4.2
       gemfile: gemfiles/rails4.2.gemfile
-    - rvm: jruby
+    - rvm: jruby-9.1.9.0
       gemfile: gemfiles/rails5.0.gemfile
-    - rvm: jruby
+    - rvm: jruby-9.1.9.0
       gemfile: gemfiles/rails5.1.gemfile
   include:
     - rvm: 2.3.4

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ By default, Kasket will cache each instance collection with a maximum length of 
 You can override this by passing the `:max_collection_size` option to the `Kasket.setup` call:
 
 ```ruby
-Kasket.setup(:max_collection_size => 50)
+Kasket.setup(max_collection_size: 50)
 ```
 
 #### Write-Through Caching
@@ -45,7 +45,7 @@ You can pass ':write_through => true' to the `Kasket.setup` call to get write-th
 semantics instead. In this mode, the model will be updated in the cache as well as the database.
 
 ```ruby
-Kasket.setup(:write_through => true)
+Kasket.setup(write_through: true)
 ```
 
 ## Configuring caching of your models
@@ -102,7 +102,7 @@ All Kasket cache keys contain the Kasket version number, so upgrading Kasket wil
 Sometimes caches like memcache can become incoherent. One layer of mitigation for this problem is to specify the maximum length a value may stay in cache before being expired and re-calculated. You can configure an optional default TTL value at setup:
 
 ```ruby
-Kasket.setup(:default_expires_in => 24.hours)
+Kasket.setup(default_expires_in: 24.hours)
 ```
 
 You can further specify per-model TTL values:

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This will include the required modules into ActiveRecord.
 By default, Kasket will cache each instance collection with a maximum length of 100.
 You can override this by passing the `:max_collection_size` option to the `Kasket.setup` call:
 
-```
+```ruby
 Kasket.setup(:max_collection_size => 50)
 ```
 
@@ -44,7 +44,7 @@ By default, when a model is saved, Kasket will invalidate cache entries by delet
 You can pass ':write_through => true' to the `Kasket.setup` call to get write-through cache
 semantics instead. In this mode, the model will be updated in the cache as well as the database.
 
-```
+```ruby
 Kasket.setup(:write_through => true)
 ```
 
@@ -55,7 +55,7 @@ configuration.
 
 If you have an `Account` model, you can can do the simplest caching configuration like:
 
-```
+```ruby
 Account.has_kasket
 ```
 
@@ -65,7 +65,7 @@ All other calls (say, `Account.find_by_subdomain('zendesk')`) are untouched.
 
 If you wanted to configure a caching index on the subdomain attribute of the Account model, you would simply write
 
-```
+```ruby
 Account.has_kasket_on :subdomain
 ```
 
@@ -81,6 +81,7 @@ The goal of Kasket is to be as safe as possible to use, so the cache is expired 
 * When you save a model instance
 * When your database schema changes
 * When you install a new version of Kasket
+* After a global or per-model TTL
 * When you ask it to
 
 ### Cache expiry on instance save
@@ -96,12 +97,26 @@ If you somehow change your table schema, all cache entries for that table will a
 
 All Kasket cache keys contain the Kasket version number, so upgrading Kasket will expire all Kasket cache entries.
 
+### Cache expiry by TTL
+
+Sometimes caches like memcache can become incoherent. One layer of mitigation for this problem is to specify the maximum length a value may stay in cache before being expired and re-calculated. You can configure an optional default TTL value at setup:
+
+```ruby
+Kasket.setup(:default_expires_in => 24.hours)
+```
+
+You can further specify per-model TTL values:
+
+```ruby
+Account.kasket_expires_in 5.minutes
+```
+
 ### Manually expiring caches
 
 If you have model methods that update the database behind the back of ActiveRecord, you need to mark these methods
 as being dirty.
 
-```
+```ruby
 Account.kasket_dirty_methods :update_last_action
 ```
 

--- a/lib/kasket.rb
+++ b/lib/kasket.rb
@@ -15,7 +15,11 @@ module Kasket
   autoload :SelectManagerMixin,     'kasket/select_manager_mixin'
   autoload :RelationMixin,          'kasket/relation_mixin'
 
-  CONFIGURATION = { max_collection_size: 100, write_through: false } # rubocop:disable Style/MutableConstant
+  CONFIGURATION = { # rubocop:disable Style/MutableConstant
+    max_collection_size: 100,
+    write_through:       false,
+    default_expires_in:  nil
+  }
 
   module_function
 
@@ -23,7 +27,8 @@ module Kasket
     return if ActiveRecord::Base.respond_to?(:has_kasket)
 
     CONFIGURATION[:max_collection_size] = options[:max_collection_size] if options[:max_collection_size]
-    CONFIGURATION[:write_through] = options[:write_through] if options[:write_through]
+    CONFIGURATION[:write_through]       = options[:write_through]       if options[:write_through]
+    CONFIGURATION[:default_expires_in]  = options[:default_expires_in]  if options[:default_expires_in]
 
     ActiveRecord::Base.extend(Kasket::ConfigurationMixin)
 

--- a/lib/kasket/configuration_mixin.rb
+++ b/lib/kasket/configuration_mixin.rb
@@ -91,7 +91,10 @@ module Kasket
       @kasket_ttl = time
     end
 
-    attr_reader :kasket_ttl
+    def kasket_ttl
+      @kasket_ttl ||= nil
+      @kasket_ttl || Kasket::CONFIGURATION[:default_expires_in]
+    end
 
     private
 

--- a/test/configuration_mixin_test.rb
+++ b/test/configuration_mixin_test.rb
@@ -42,4 +42,24 @@ describe "configuration mixin" do
       assert_equal "kasket-#{protocol}/R#{ar_version}/posts/version=#{POST_VERSION}/", Post.kasket_key_prefix
     end
   end
+
+  describe "kasket_ttl" do
+    describe "with an explicit TTL" do
+      it "returns the local TTL" do
+        assert_equal 5.minutes, ExpiringComment.kasket_ttl
+      end
+    end
+
+    describe "without an explicit TTL" do
+      it "falls back to the global" do
+        begin
+          previous = Kasket::CONFIGURATION[:default_expires_in]
+          Kasket::CONFIGURATION[:default_expires_in] = 86401
+          assert_equal 5.minutes, DefaultComment.kasket_ttl
+        ensure
+          Kasket::CONFIGURATION[:default_expires_in] = previous
+        end
+      end
+    end
+  end
 end

--- a/test/configuration_mixin_test.rb
+++ b/test/configuration_mixin_test.rb
@@ -55,7 +55,7 @@ describe "configuration mixin" do
         begin
           previous = Kasket::CONFIGURATION[:default_expires_in]
           Kasket::CONFIGURATION[:default_expires_in] = 86401
-          assert_equal 5.minutes, DefaultComment.kasket_ttl
+          assert_equal 86401, DefaultComment.kasket_ttl
         ensure
           Kasket::CONFIGURATION[:default_expires_in] = previous
         end


### PR DESCRIPTION
Kasket is susceptible to [cache incoherency](https://en.wikipedia.org/wiki/Cache_coherence), because the values underlying a key frequently mutate. We have evidence of encountering this problem regularly. Network partitions can cause the target memcache node to be disconnected from the client attempting to explicitly invalidate a shard. Changing a memcache namespace upgrading Ruby or Rails can cause stale values after a rollback. Coherency can be a serious problem. As an example of a worst case situation, consider that an stale value for an account shard_id after an account move could cause data to be written to the wrong database.

TTLs are not a complete stand alone solution to this problem. They're just another layer in the safety net to prevent stale values from being indefinitely returned. They allow us to cap the worst-case-scenario and ensure eventual consistency. Separately, we may want to investigate [mcrouter](https://code.facebook.com/posts/296442737213493/introducing-mcrouter-a-memcached-protocol-router-for-scaling-memcached-deployments/) for tackling the network partition issue, and [scaled coherency checks](https://www.youtube.com/watch?v=kxMKnx__uso).

### Risks

This introduces overhead of having to re-fetch values that may have been correct in the cache. This can also cause echo of the stampede that happens after a `Rails.cache.clear`. Both of these seem acceptable to the alternative of returning an incoherent value. This PR does not change the default behavior by enforcing an opinion on the TTL. In practice, I would advocate for an initial value around 24 hours.

/cc @zendesk/infrastructure @zendesk/sustaining 