### PR TITLE
add basic statsd timing on cache reads and writes

### DIFF
--- a/gemfiles/rails3.2.gemfile
+++ b/gemfiles/rails3.2.gemfile
@@ -2,6 +2,6 @@ eval_gemfile('./common.rb')
 
 gem 'activerecord', '~> 3.2.1'
 gem 'minitest', '~> 4.7.5'
-gem 'mysql2', '~> 0.3.0', platforms: :ruby
+gem 'mysql2', '~> 0.3.0'
 gem 'test-unit-minitest'
 gem 'test_after_commit', '0.4.2'

--- a/gemfiles/rails3.2.gemfile
+++ b/gemfiles/rails3.2.gemfile
@@ -1,4 +1,4 @@
-eval_gemfile('gemfiles/common.rb')
+eval_gemfile('./common.rb')
 
 gem 'activerecord', '~> 3.2.1'
 gem 'minitest', '~> 4.7.5'

--- a/gemfiles/rails4.2.gemfile
+++ b/gemfiles/rails4.2.gemfile
@@ -1,5 +1,5 @@
 eval_gemfile('./common.rb')
 
 gem 'activerecord', '~> 4.2.3'
-gem 'mysql2', platforms: :ruby
+gem 'mysql2'
 gem 'test_after_commit', '0.4.2'

--- a/gemfiles/rails4.2.gemfile
+++ b/gemfiles/rails4.2.gemfile
@@ -1,4 +1,4 @@
-eval_gemfile('gemfiles/common.rb')
+eval_gemfile('./common.rb')
 
 gem 'activerecord', '~> 4.2.3'
 gem 'mysql2', platforms: :ruby

--- a/gemfiles/rails5.0.gemfile
+++ b/gemfiles/rails5.0.gemfile
@@ -1,4 +1,4 @@
-eval_gemfile('gemfiles/common.rb')
+eval_gemfile('./common.rb')
 
 gem 'activerecord', '~> 5.0.5'
 gem 'mysql2', platforms: :ruby

--- a/gemfiles/rails5.0.gemfile
+++ b/gemfiles/rails5.0.gemfile
@@ -1,4 +1,4 @@
 eval_gemfile('./common.rb')
 
 gem 'activerecord', '~> 5.0.5'
-gem 'mysql2', platforms: :ruby
+gem 'mysql2'

--- a/gemfiles/rails5.1.gemfile
+++ b/gemfiles/rails5.1.gemfile
@@ -1,4 +1,4 @@
-eval_gemfile('gemfiles/common.rb')
+eval_gemfile('./common.rb')
 
 gem 'activerecord', '~> 5.1.0'
 gem 'mysql2', platforms: :ruby

--- a/gemfiles/rails5.1.gemfile
+++ b/gemfiles/rails5.1.gemfile
@@ -1,4 +1,4 @@
 eval_gemfile('./common.rb')
 
 gem 'activerecord', '~> 5.1.0'
-gem 'mysql2', platforms: :ruby
+gem 'mysql2'

--- a/lib/kasket.rb
+++ b/lib/kasket.rb
@@ -14,6 +14,7 @@ module Kasket
   autoload :Visitor,                'kasket/visitor'
   autoload :SelectManagerMixin,     'kasket/select_manager_mixin'
   autoload :RelationMixin,          'kasket/relation_mixin'
+  autoload :Instrumentation,        'kasket/instrumentation'
 
   CONFIGURATION = { # rubocop:disable Style/MutableConstant
     max_collection_size: 100,
@@ -59,5 +60,14 @@ module Kasket
 
   def self.clear_pending_records
     Thread.current[:kasket_pending_records] = nil
+  end
+
+  def self.statsd_client
+    @statsd_client
+  end
+
+  def self.statsd_client=(client)
+    client.namespace ||= 'kasket' if client
+    @statsd_client = client
   end
 end

--- a/lib/kasket/instrumentation.rb
+++ b/lib/kasket/instrumentation.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Kasket
+  module Instrumentation
+    def instrument(metric, &block)
+      return yield unless Kasket.statsd_client
+
+      model_name = self.class.name == 'Class' ? name : self.class.name
+
+      Kasket.statsd_client.time(metric, tags: %W[model:#{model_name}], &block)
+    end
+  end
+end

--- a/lib/kasket/write_mixin.rb
+++ b/lib/kasket/write_mixin.rb
@@ -21,6 +21,8 @@ module Kasket
     end
 
     module InstanceMethods
+      include Kasket::Instrumentation
+
       def kasket_key
         @kasket_key ||= new_record? ? nil : self.class.kasket_key_for_id(id)
       end
@@ -32,7 +34,7 @@ module Kasket
       def store_in_kasket(key = kasket_key)
         if kasket_cacheable? && key
           options = { expires_in: self.class.kasket_ttl } if self.class.kasket_ttl
-          Kasket.cache.write(key, attributes_before_type_cast.dup, options)
+          instrument('cache.write') { Kasket.cache.write(key, attributes_before_type_cast.dup, options) }
           key
         end
       end

--- a/test/read_mixin_test.rb
+++ b/test/read_mixin_test.rb
@@ -150,4 +150,27 @@ describe Kasket::ReadMixin do
       end
     end
   end
+
+  describe 'instrumentation' do
+    describe 'when a statsd client is configured' do
+      let(:statsd) { stub }
+
+      before do
+        statsd.stubs(:namespace)
+        statsd.stubs(:namespace=)
+        Kasket.statsd_client = statsd
+      end
+
+      after do
+        Kasket.statsd_client = nil
+      end
+
+      it 'instruments cache reads' do
+        statsd.expects(:time).with('cache.read', tags: ['model:Post'])
+        statsd.expects(:time).with('cache.write', tags: ['model:Post'])
+
+        Post.find(1)
+      end
+    end
+  end
 end


### PR DESCRIPTION
The first commit just fixes bundler. 

The second commit adds basic instrumentation on cache reads and writes. It provides the option to set a StatsD client globally with `Kasket.statsd_client=` and the `Instrumentation` module does a simple nil check to see if the client is set. If the client is set, then record timing of the block, otherwise just yield.

/cc @zendesk/support-platform @ggrossman @gabetax 