### PR TITLE
drop support for ruby 2.2 and activerecord 3.2, build on ruby 2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,6 @@ matrix:
     - rvm: jruby-9.1.9.0
       gemfile: gemfiles/rails5.1.gemfile
   include:
-    - rvm: 2.3.4
+    - rvm: 2.3
       script: bundle exec rubocop
       gemfile: gemfiles/rails5.1.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,23 +8,18 @@ branches:
   only: master
 
 rvm:
-  - 2.2.7
-  - 2.3.4
-  - 2.4.2
+  - 2.3
+  - 2.4
+  - 2.5
   - jruby-9.1.9.0
 
 gemfile:
-  - gemfiles/rails3.2.gemfile
   - gemfiles/rails4.2.gemfile
   - gemfiles/rails5.0.gemfile
   - gemfiles/rails5.1.gemfile
 
 matrix:
   exclude:
-    - rvm: 2.4.2
-      gemfile: gemfiles/rails3.2.gemfile
-    - rvm: 2.4.2
-      gemfile: gemfiles/rails4.2.gemfile
     - rvm: jruby-9.1.9.0
       gemfile: gemfiles/rails5.0.gemfile
     - rvm: jruby-9.1.9.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,13 +15,10 @@ rvm:
 
 gemfile:
   - gemfiles/rails4.2.gemfile
-  - gemfiles/rails5.0.gemfile
   - gemfiles/rails5.1.gemfile
 
 matrix:
   exclude:
-    - rvm: jruby-9.1.9.0
-      gemfile: gemfiles/rails5.0.gemfile
     - rvm: jruby-9.1.9.0
       gemfile: gemfiles/rails5.1.gemfile
   include:

--- a/gemfiles/rails3.2.gemfile
+++ b/gemfiles/rails3.2.gemfile
@@ -1,7 +1,0 @@
-eval_gemfile('gemfiles/common.rb')
-
-gem 'activerecord', '~> 3.2.1'
-gem 'minitest', '~> 4.7.5'
-gem 'mysql2', '~> 0.3.0', platforms: :ruby
-gem 'test-unit-minitest'
-gem 'test_after_commit', '0.4.2'

--- a/gemfiles/rails4.2.gemfile
+++ b/gemfiles/rails4.2.gemfile
@@ -1,4 +1,4 @@
-eval_gemfile('gemfiles/common.rb')
+eval_gemfile('./common.rb')
 
 gem 'activerecord', '~> 4.2.3'
 gem 'mysql2', platforms: :ruby

--- a/gemfiles/rails4.2.gemfile
+++ b/gemfiles/rails4.2.gemfile
@@ -1,5 +1,5 @@
 eval_gemfile('./common.rb')
 
 gem 'activerecord', '~> 4.2.3'
-gem 'mysql2', platforms: :ruby
+gem 'mysql2', '>= 0.3.13', '< 0.5', platforms: :ruby
 gem 'test_after_commit', '0.4.2'

--- a/gemfiles/rails5.0.gemfile
+++ b/gemfiles/rails5.0.gemfile
@@ -1,4 +1,0 @@
-eval_gemfile('./common.rb')
-
-gem 'activerecord', '~> 5.0.5'
-gem 'mysql2', platforms: :ruby

--- a/gemfiles/rails5.0.gemfile
+++ b/gemfiles/rails5.0.gemfile
@@ -1,4 +1,4 @@
-eval_gemfile('gemfiles/common.rb')
+eval_gemfile('./common.rb')
 
 gem 'activerecord', '~> 5.0.5'
 gem 'mysql2', platforms: :ruby

--- a/gemfiles/rails5.1.gemfile
+++ b/gemfiles/rails5.1.gemfile
@@ -1,4 +1,4 @@
 eval_gemfile('./common.rb')
 
 gem 'activerecord', '~> 5.1.0'
-gem 'mysql2', platforms: :ruby
+gem 'mysql2', '>= 0.3.18', '< 0.6.0', platforms: :ruby

--- a/gemfiles/rails5.1.gemfile
+++ b/gemfiles/rails5.1.gemfile
@@ -1,4 +1,4 @@
-eval_gemfile('gemfiles/common.rb')
+eval_gemfile('./common.rb')
 
 gem 'activerecord', '~> 5.1.0'
 gem 'mysql2', platforms: :ruby

--- a/kasket.gemspec
+++ b/kasket.gemspec
@@ -12,9 +12,9 @@ Gem::Specification.new do |s|
   s.license     = "Apache License Version 2.0"
   s.files       = Dir.glob("lib/**/*") + %w[README.md]
 
-  s.required_ruby_version = '>= 2.2.0'
+  s.required_ruby_version = '>= 2.3.0'
 
-  s.add_runtime_dependency("activerecord", ">= 3.2", "< 5.2")
+  s.add_runtime_dependency("activerecord", ">= 4.2", "< 5.2")
 
   s.add_development_dependency("rake")
   s.add_development_dependency("bundler")


### PR DESCRIPTION
- Drop support for unmaintained Ruby 2.2
- Drop support for ActiveRecord 3.2
- Add a build matrix for Ruby 2.5
- Removes the patch specification for each Ruby version in the travis matrix to let Travis pull latest
- Fix the gemfiles references so `bundle install` succeeds
- Update the gemspec to reflect supported versions

/cc @zendesk/support-platform @gabetax @bquorning @pschambacher @grosser 