### PR TITLE
downgrade the empty results message to debug level logs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ jobs:
   # JRuby
   test-jruby-with-4.2:
     docker:
-      - image: circleci/jruby:9.1
+      - image: circleci/jruby:9.2
       - image: circleci/mysql:5.7
     environment:
       BUNDLE_GEMFILE: gemfiles/rails4.2.gemfile

--- a/lib/kasket/read_mixin.rb
+++ b/lib/kasket/read_mixin.rb
@@ -76,7 +76,7 @@ module Kasket
       if records.size == 1
         records.first.store_in_kasket(key)
       elsif records.empty?
-        ActiveRecord::Base.logger.info("[KASKET] would have stored an empty resultset") if ActiveRecord::Base.logger
+        ActiveRecord::Base.logger.debug("[KASKET] would have stored an empty resultset") if ActiveRecord::Base.logger
       elsif records.size <= Kasket::CONFIGURATION[:max_collection_size]
         if records.all?(&:kasket_cacheable?)
           instance_keys = records.map(&:store_in_kasket)

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -2,7 +2,7 @@
 require 'bundler/setup'
 require 'minitest/autorun'
 require 'minitest/rg'
-require 'mocha/setup'
+require 'mocha/minitest'
 require 'active_record'
 require 'logger'
 require 'timecop'
@@ -72,6 +72,6 @@ module Rails
   end
 end
 
-require './test/test_models'
+require_relative './test_models'
 POST_VERSION = Post.column_names.join.sum
 COMMENT_VERSION = Comment.column_names.join.sum


### PR DESCRIPTION
This isn't really helpful information in many situations, so I think it fits debug messaging better. 