### PR TITLE
Compatibility with Rails 5.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,28 +2,6 @@ version: 2
 
 jobs:
 
-  # Ruby 2.4
-  test-2.4-with-4.2:
-    docker:
-      - image: circleci/ruby:2.4
-      - image: circleci/mysql:5.7
-    environment:
-      BUNDLE_GEMFILE: gemfiles/rails4.2.gemfile
-    steps:
-      - checkout
-      - run: bundle install
-      - run: bundle exec rake test
-  test-2.4-with-5.1:
-    docker:
-      - image: circleci/ruby:2.4
-      - image: circleci/mysql:5.7
-    environment:
-      BUNDLE_GEMFILE: gemfiles/rails5.1.gemfile
-    steps:
-      - checkout
-      - run: bundle install
-      - run: bundle exec rake test
-
   # Ruby 2.5
   test-2.5-with-4.2:
     docker:
@@ -117,9 +95,6 @@ workflows:
   version: 2
   build:
     jobs:
-
-      - test-2.4-with-4.2
-      - test-2.4-with-5.1
 
       - test-2.5-with-4.2
       - test-2.5-with-5.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,6 +57,17 @@ jobs:
       - run: bundle install
       - run: bundle exec rake test
 
+  test-2.5-with-6.0:
+    docker:
+      - image: circleci/ruby:2.5
+      - image: circleci/mysql:5.7
+    environment:
+      BUNDLE_GEMFILE: gemfiles/rails6.0.gemfile
+    steps:
+      - checkout
+      - run: bundle install
+      - run: bundle exec rake test
+
   # Ruby 2.6
   test-2.6-with-5.1:
     docker:
@@ -75,6 +86,17 @@ jobs:
       - image: circleci/mysql:5.7
     environment:
       BUNDLE_GEMFILE: gemfiles/rails5.2.gemfile
+    steps:
+      - checkout
+      - run: bundle install
+      - run: bundle exec rake test
+
+  test-2.6-with-6.0:
+    docker:
+      - image: circleci/ruby:2.6
+      - image: circleci/mysql:5.7
+    environment:
+      BUNDLE_GEMFILE: gemfiles/rails6.0.gemfile
     steps:
       - checkout
       - run: bundle install
@@ -113,10 +135,12 @@ workflows:
 
       - test-2.5-with-4.2
       - test-2.5-with-5.1
-      - test-2.6-with-5.1
+      - test-2.6-with-5.2
+      - test-2.6-with-6.0
 
       - test-2.6-with-5.1
       - test-2.6-with-5.2
+      - test-2.6-with-6.0
 
       - test-jruby-with-4.2
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,18 +102,6 @@ jobs:
       - run: bundle install
       - run: bundle exec rake test
 
-  # JRuby
-  test-jruby-with-4.2:
-    docker:
-      - image: circleci/jruby:9.1
-      - image: circleci/mysql:5.7
-    environment:
-      BUNDLE_GEMFILE: gemfiles/rails4.2.gemfile
-    steps:
-      - checkout
-      - run: bundle install
-      - run: bundle exec rake test
-
   # RuboCop
   rubocop:
     docker:
@@ -141,7 +129,5 @@ workflows:
       - test-2.6-with-5.1
       - test-2.6-with-5.2
       - test-2.6-with-6.0
-
-      - test-jruby-with-4.2
 
       - rubocop

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,28 +2,6 @@ version: 2
 
 jobs:
 
-  # Ruby 2.3
-  test-2.3-with-4.2:
-    docker:
-      - image: circleci/ruby:2.3
-      - image: circleci/mysql:5.7
-    environment:
-      BUNDLE_GEMFILE: gemfiles/rails4.2.gemfile
-    steps:
-      - checkout
-      - run: bundle install
-      - run: bundle exec rake test
-  test-2.3-with-5.1:
-    docker:
-      - image: circleci/ruby:2.3
-      - image: circleci/mysql:5.7
-    environment:
-      BUNDLE_GEMFILE: gemfiles/rails5.1.gemfile
-    steps:
-      - checkout
-      - run: bundle install
-      - run: bundle exec rake test
-
   # Ruby 2.4
   test-2.4-with-4.2:
     docker:
@@ -68,6 +46,40 @@ jobs:
       - run: bundle install
       - run: bundle exec rake test
 
+  test-2.5-with-5.2:
+    docker:
+      - image: circleci/ruby:2.5
+      - image: circleci/mysql:5.7
+    environment:
+      BUNDLE_GEMFILE: gemfiles/rails5.2.gemfile
+    steps:
+      - checkout
+      - run: bundle install
+      - run: bundle exec rake test
+
+  # Ruby 2.6
+  test-2.6-with-5.1:
+    docker:
+      - image: circleci/ruby:2.6
+      - image: circleci/mysql:5.7
+    environment:
+      BUNDLE_GEMFILE: gemfiles/rails5.1.gemfile
+    steps:
+      - checkout
+      - run: bundle install
+      - run: bundle exec rake test
+
+  test-2.6-with-5.2:
+    docker:
+      - image: circleci/ruby:2.6
+      - image: circleci/mysql:5.7
+    environment:
+      BUNDLE_GEMFILE: gemfiles/rails5.2.gemfile
+    steps:
+      - checkout
+      - run: bundle install
+      - run: bundle exec rake test
+
   # JRuby
   test-jruby-with-4.2:
     docker:
@@ -96,14 +108,15 @@ workflows:
   build:
     jobs:
 
-      - test-2.3-with-4.2
-      - test-2.3-with-5.1
-
       - test-2.4-with-4.2
       - test-2.4-with-5.1
 
       - test-2.5-with-4.2
       - test-2.5-with-5.1
+      - test-2.6-with-5.1
+
+      - test-2.6-with-5.1
+      - test-2.6-with-5.2
 
       - test-jruby-with-4.2
 

--- a/gemfiles/rails5.2.gemfile
+++ b/gemfiles/rails5.2.gemfile
@@ -1,0 +1,4 @@
+eval_gemfile('./common.rb')
+
+gem 'activerecord', '~> 5.2.0'
+gem 'mysql2', '>= 0.5.3', '< 0.6.0', platforms: :ruby

--- a/gemfiles/rails6.0.gemfile
+++ b/gemfiles/rails6.0.gemfile
@@ -1,0 +1,4 @@
+eval_gemfile('./common.rb')
+
+gem 'activerecord', '~> 6.0.3'
+gem 'mysql2', '>= 0.5.3', '< 0.6.0', platforms: :ruby

--- a/kasket.gemspec
+++ b/kasket.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.3.0'
 
-  s.add_runtime_dependency("activerecord", ">= 4.2", "< 6.0")
+  s.add_runtime_dependency("activerecord", ">= 4.2", "< 6.1")
 
   s.add_development_dependency("rake")
   s.add_development_dependency("bundler")

--- a/kasket.gemspec
+++ b/kasket.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.3.0'
 
-  s.add_runtime_dependency("activerecord", ">= 4.2", "< 5.2")
+  s.add_runtime_dependency("activerecord", ">= 4.2", "< 6.0")
 
   s.add_development_dependency("rake")
   s.add_development_dependency("bundler")

--- a/lib/kasket/configuration_mixin.rb
+++ b/lib/kasket/configuration_mixin.rb
@@ -37,7 +37,7 @@ module Kasket
       else
         key = attribute_value_pairs.map do |attribute, value|
           column = columns_hash[attribute.to_s]
-          value = nil if value.blank?
+          value = nil if value.blank? && value != false
           "#{attribute}=#{kasket_quoted_value_for_column(value, column)}"
         end.join('/')
 

--- a/lib/kasket/read_mixin.rb
+++ b/lib/kasket/read_mixin.rb
@@ -16,7 +16,7 @@ module Kasket
           if ActiveRecord::VERSION::MAJOR < 5
             sql.to_kasket_query(self, args[1])
           else
-            if ActiveRecord::VERSION::MINOR < 2
+            if ActiveRecord::VERSION::STRING < '5.2'
               sql.to_kasket_query(self, args[1].map(&:value_for_database))
             else
               sql.to_kasket_query(self)

--- a/lib/kasket/read_mixin.rb
+++ b/lib/kasket/read_mixin.rb
@@ -16,7 +16,11 @@ module Kasket
           if ActiveRecord::VERSION::MAJOR < 5
             sql.to_kasket_query(self, args[1])
           else
-            sql.to_kasket_query(self, args[1].map(&:value_for_database))
+            if ActiveRecord::VERSION::MINOR < 2
+              sql.to_kasket_query(self, args[1].map(&:value_for_database))
+            else
+              sql.to_kasket_query(self)
+            end
           end
         else
           kasket_parser.parse(sanitize_sql(sql))

--- a/lib/kasket/relation_mixin.rb
+++ b/lib/kasket/relation_mixin.rb
@@ -6,7 +6,7 @@ module Kasket
         if ActiveRecord::VERSION::MAJOR < 5
           arel.to_kasket_query(klass, (binds || bind_values))
         else
-          arel.to_kasket_query(klass, (@values[:where].binds.map(&:value_for_database) + Array(@values[:limit])))
+          arel.to_kasket_query(klass, (@values[:where].to_h.values + Array(@values[:limit])))
         end
       end
     rescue TypeError # unsupported object in ast

--- a/lib/kasket/visitor.rb
+++ b/lib/kasket/visitor.rb
@@ -123,7 +123,7 @@ module Kasket
       if ActiveRecord::VERSION::MAJOR < 5
         visit(@binds.shift[1])
       else
-        if ActiveRecord::VERSION::MINOR < 2
+        if ActiveRecord::VERSION::STRING < '5.2'
           visit(@binds.shift)
         else
           visit(node.value.value) unless node.value.value.nil?

--- a/lib/kasket/visitor.rb
+++ b/lib/kasket/visitor.rb
@@ -119,11 +119,15 @@ module Kasket
       end
     end
 
-    def visit_Arel_Nodes_BindParam(_x, *_)
+    def visit_Arel_Nodes_BindParam(node, *_)
       if ActiveRecord::VERSION::MAJOR < 5
         visit(@binds.shift[1])
       else
-        visit(@binds.shift)
+        if ActiveRecord::VERSION::MINOR < 2
+          visit(@binds.shift)
+        else
+          visit(node.value.value) unless node.value.value.nil?
+        end
       end
     end
 

--- a/test/cache_expiry_test.rb
+++ b/test/cache_expiry_test.rb
@@ -39,7 +39,7 @@ describe "cache expiry" do
 
     it "loads a fresh copy when reload is called" do
       Post.where(id: @post.id).update_all(title: 'sneaky')
-      @post.reload.title.must_equal 'sneaky'
+      assert_equal @post.reload.title, 'sneaky'
     end
 
     it "clears all indices for instance when updated" do

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -2,7 +2,7 @@
 require 'bundler/setup'
 require 'minitest/autorun'
 require 'minitest/rg'
-require 'mocha/setup'
+require 'mocha/minitest'
 require 'active_record'
 require 'logger'
 require 'timecop'

--- a/test/read_mixin_test.rb
+++ b/test/read_mixin_test.rb
@@ -107,10 +107,10 @@ describe Kasket::ReadMixin do
   it "expires the cache when the expires_in option is set" do
     old = ExpiringComment.find(1).updated_at
     ExpiringComment.where(id: 1).update_all(updated_at: Time.now + 10.seconds)
-    ExpiringComment.find(1).updated_at.must_equal old # caching works
+    assert_equal ExpiringComment.find(1).updated_at, old # caching works
 
     Timecop.travel(Time.now + 6.minutes) do
-      ExpiringComment.find(1).updated_at.wont_equal old # cache expired
+      assert ExpiringComment.find(1).updated_at != old # cache expired
     end
   end
 
@@ -133,9 +133,9 @@ describe Kasket::ReadMixin do
     end
 
     it "finds cached when searching by column" do
-      Post.where(title: 'no_comments').first.title.must_equal 'no_comments'
+      assert_equal Post.where(title: 'no_comments').first.title, 'no_comments'
       Post.expects(:find_by_sql_without_kasket).never
-      Post.where(title: 'no_comments').first.title.must_equal 'no_comments'
+      assert_equal Post.where(title: 'no_comments').first.title, 'no_comments'
     end
 
     it "returns nothing if object destroyed" do

--- a/test/visitor_test.rb
+++ b/test/visitor_test.rb
@@ -52,7 +52,7 @@ describe Kasket::Visitor do
       attributes: [[:public, 1]],
       from: "comments",
       index: [:public],
-      key: "#{DefaultComment.kasket_key_prefix}public=1"
+      key: "#{DefaultComment.kasket_key_prefix}public=#{ActiveRecord::VERSION::STRING < '5.2' ? "1" : "true"}"
     }
     assert_equal expected, DefaultComment.unscoped.where(public: true).to_kasket_query
 
@@ -60,7 +60,7 @@ describe Kasket::Visitor do
       attributes: [[:public, 0]],
       from: "comments",
       index: [:public],
-      key: "#{DefaultComment.kasket_key_prefix}public=0"
+      key: "#{DefaultComment.kasket_key_prefix}public=#{ActiveRecord::VERSION::STRING < '5.2' ? "0" : "false"}"
     }
     assert_equal expected, DefaultComment.unscoped.where(public: false).to_kasket_query
   end

--- a/test/visitor_test.rb
+++ b/test/visitor_test.rb
@@ -23,7 +23,7 @@ describe Kasket::Visitor do
 
   it "builds select Bignum" do
     num = 9223372036854775807
-    Post.where(big_id: num).to_kasket_query.fetch(:attributes).must_equal([[:big_id, num.to_s]])
+    assert_equal Post.where(big_id: num).to_kasket_query.fetch(:attributes), [[:big_id, num.to_s]]
   end
 
   it "builds with nil values" do


### PR DESCRIPTION
🚄 

/cc @zendesk/classic-upgrade 

## Description
The main change is located in the visitor as the bindings aren't kept separate anymore but are parts of the nodes themselves.
A test had to be fixed to take into account booleans being now defined as... booleans...

## References
This is the Rails commit that triggered the changes: https://github.com/rails/rails/commit/213796fb4936dce1da2f0c097a054e1af5c25c2c#diff-c9d167bac00ff2f45c5b5e035e8a80e8
