### PR TITLE
Add @zendesk/database-gem-owners as codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @zendesk/database-gem-owners


### PR DESCRIPTION
Looking through the commit history, those in the group are already the unofficial owners. Let's make it official.

@craig-day, @grosser did you want to be added to the group or listed separately as an owner?