### PR TITLE
Clean-up of code not necessary with Rails 5.2+

### DIFF
--- a/lib/kasket/read_mixin.rb
+++ b/lib/kasket/read_mixin.rb
@@ -8,6 +8,7 @@ module Kasket
       end
     end
 
+    # *args can be replaced with (sql, *args) once we stop supporting Rails < 5.2
     def find_by_sql_with_kasket(*args)
       sql = args[0]
 

--- a/lib/kasket/relation_mixin.rb
+++ b/lib/kasket/relation_mixin.rb
@@ -1,12 +1,15 @@
 # frozen_string_literal: true
 module Kasket
   module RelationMixin
+    # binds can be removed when support for Rails < 5 is removed
     def to_kasket_query(binds = nil)
       if arel.is_a?(Arel::SelectManager)
         if ActiveRecord::VERSION::MAJOR < 5
           arel.to_kasket_query(klass, (binds || bind_values))
-        else
+        elsif ActiveRecord::VERSION::STRING < '5.2'
           arel.to_kasket_query(klass, (@values[:where].to_h.values + Array(@values[:limit])))
+        else
+          arel.to_kasket_query(klass)
         end
       end
     rescue TypeError # unsupported object in ast

--- a/lib/kasket/select_manager_mixin.rb
+++ b/lib/kasket/select_manager_mixin.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 module Kasket
   module SelectManagerMixin
+    # binds can be removed once we stop supporting Rails < 5.2
     def to_kasket_query(klass, binds = [])
       begin
         query = Kasket::Visitor.new(klass, binds).accept(ast)


### PR DESCRIPTION
## Description
Now that we have all the information we need in the AST, we don't need to carry bindings around.
Since we're still supporting Rails 4.2-5.0-5.1, we can't just delete the code but I added some comments to remind ourselves to delete the code.
I also found that some of the visitor methods won't be necessary anymore.