### PR TITLE
Fix rubocop offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,15 +1,18 @@
 AllCops:
   DisplayCopNames: true
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.5
   Exclude:
     - vendor/**/*
     - gemfiles/vendor/**/*
     - tmp/**/*
 
+Layout/LineLength:
+  Max: 170
+
 Bundler/OrderedGems:
   Enabled: false
 
-Layout/AlignParameters:
+Layout/ParameterAlignment:
   EnforcedStyle: with_fixed_indentation
 
 Layout/CommentIndentation:
@@ -24,10 +27,10 @@ Layout/EmptyLineAfterMagicComment:
 Layout/FirstParameterIndentation:
   EnforcedStyle: consistent
 
-Layout/IndentArray:
+Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
 
-Layout/IndentHash:
+Layout/FirstHashElementIndentation:
   EnforcedStyle: consistent
 
 Layout/MultilineMethodCallIndentation:
@@ -51,7 +54,7 @@ Lint/AssignmentInCondition:
 Lint/AmbiguousOperator:
   Enabled: false
 
-Lint/EndAlignment:
+Layout/EndAlignment:
   EnforcedStyleAlignWith: variable
 
 Lint/ShadowingOuterLocalVariable:
@@ -95,7 +98,7 @@ Style/IfUnlessModifier:
 Style/Lambda:
   Enabled: false
 
-Style/MethodName:
+Naming/MethodName:
   Exclude:
     - lib/kasket/visitor.rb
 
@@ -111,7 +114,7 @@ Style/NumericPredicate:
 Style/PerlBackrefs:
   Enabled: false
 
-Style/PredicateName:
+Naming/PredicateName:
   Enabled: false
 
 # for single `/` more readable
@@ -146,10 +149,13 @@ Style/SymbolArray:
 Style/TernaryParentheses:
   Enabled: false
 
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
   Enabled: false
 
-Style/VariableNumber:
+Style/TrailingCommaInHashLiteral:
+  Enabled: false
+
+Naming/VariableNumber:
   Enabled: false
 
 Style/WordArray:

--- a/gemfiles/common.rb
+++ b/gemfiles/common.rb
@@ -3,6 +3,6 @@ source 'https://rubygems.org'
 
 gem 'activerecord-jdbcmysql-adapter', '~> 1.2', platforms: :jruby
 gem 'byebug', platforms: :ruby
-gem 'rubocop', '~> 0.49.1', platforms: :ruby
+gem 'rubocop', '~> 0.89.1', platforms: :ruby
 
 gemspec path: Bundler.root.sub('/gemfiles', '')

--- a/gemfiles/rails4.2.gemfile
+++ b/gemfiles/rails4.2.gemfile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 eval_gemfile('./common.rb')
 
 gem 'activerecord', '~> 4.2.3'

--- a/gemfiles/rails5.1.gemfile
+++ b/gemfiles/rails5.1.gemfile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 eval_gemfile('./common.rb')
 
 gem 'activerecord', '~> 5.1.0'

--- a/gemfiles/rails5.2.gemfile
+++ b/gemfiles/rails5.2.gemfile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 eval_gemfile('./common.rb')
 
 gem 'activerecord', '~> 5.2.0'

--- a/gemfiles/rails6.0.gemfile
+++ b/gemfiles/rails6.0.gemfile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 eval_gemfile('./common.rb')
 
 gem 'activerecord', '~> 6.0.3'

--- a/kasket.gemspec
+++ b/kasket.gemspec
@@ -12,16 +12,16 @@ Gem::Specification.new do |s|
   s.license     = "Apache License Version 2.0"
   s.files       = Dir.glob("lib/**/*") + %w[README.md]
 
-  s.required_ruby_version = '>= 2.3.0'
+  s.required_ruby_version = '>= 2.5.0'
 
   s.add_runtime_dependency("activerecord", ">= 4.2", "< 6.1")
 
-  s.add_development_dependency("rake")
-  s.add_development_dependency("bundler")
-  s.add_development_dependency("mocha")
-  s.add_development_dependency("wwtd")
   s.add_development_dependency("bump")
+  s.add_development_dependency("bundler")
   s.add_development_dependency("minitest")
   s.add_development_dependency("minitest-rg")
+  s.add_development_dependency("mocha")
+  s.add_development_dependency("rake")
   s.add_development_dependency("timecop")
+  s.add_development_dependency("wwtd")
 end

--- a/lib/kasket.rb
+++ b/lib/kasket.rb
@@ -17,8 +17,8 @@ module Kasket
 
   CONFIGURATION = { # rubocop:disable Style/MutableConstant
     max_collection_size: 100,
-    write_through:       false,
-    default_expires_in:  nil
+    write_through: false,
+    default_expires_in: nil
   }
 
   module_function
@@ -33,8 +33,8 @@ module Kasket
     ActiveRecord::Base.extend(Kasket::ConfigurationMixin)
 
     if defined?(ActiveRecord::Relation)
-      ActiveRecord::Relation.send(:include, Kasket::RelationMixin)
-      Arel::SelectManager.send(:include, Kasket::SelectManagerMixin)
+      ActiveRecord::Relation.include Kasket::RelationMixin
+      Arel::SelectManager.include Kasket::SelectManagerMixin
     end
   end
 
@@ -42,8 +42,13 @@ module Kasket
     @cache_store = ActiveSupport::Cache.lookup_store(options)
   end
 
-  def self.cache
+  def self.cache_store
     @cache_store ||= Rails.cache
+  end
+
+  # Alias cache_store to cache
+  class << self
+    alias_method :cache, :cache_store
   end
 
   # Keys are the records being saved.

--- a/lib/kasket/query_parser.rb
+++ b/lib/kasket/query_parser.rb
@@ -6,8 +6,8 @@ module Kasket
     # SELECT * FROM `users` WHERE (`users`.`id` = 2) LIMIT 1
     # 'SELECT * FROM \'posts\' WHERE (\'posts\'.\'id\' = 574019247) '
 
-    AND = /\s+AND\s+/i
-    VALUE = /'?(\d+|\?|(?:(?:[^']|''|\\')*))'?/ # Matches: 123, ?, '123', '12''3'
+    AND = /\s+AND\s+/i.freeze
+    VALUE = /'?(\d+|\?|(?:(?:[^']|''|\\')*))'?/.freeze # Matches: 123, ?, '123', '12''3'
 
     def initialize(model_class)
       @model_class = model_class

--- a/lib/kasket/relation_mixin.rb
+++ b/lib/kasket/relation_mixin.rb
@@ -10,7 +10,7 @@ module Kasket
         end
       end
     rescue TypeError # unsupported object in ast
-      return nil
+      nil
     end
   end
 end

--- a/lib/kasket/visitor.rb
+++ b/lib/kasket/visitor.rb
@@ -75,6 +75,7 @@ module Kasket
     def visit_Arel_Nodes_JoinSource(node, *_)
       return :unsupported if !node.left || node.right.any?
       return :unsupported unless node.left.is_a?(Arel::Table)
+
       visit(node.left)
     end
 
@@ -85,6 +86,7 @@ module Kasket
     def visit_Arel_Nodes_And(node, *_)
       attributes = node.children.map { |child| visit(child) }
       return :unsupported if attributes.include?(:unsupported)
+
       attributes.sort! { |pair1, pair2| pair1[0].to_s <=> pair2[0].to_s }
       { attributes: attributes }
     end

--- a/test/configuration_mixin_test.rb
+++ b/test/configuration_mixin_test.rb
@@ -52,13 +52,11 @@ describe "configuration mixin" do
 
     describe "without an explicit TTL" do
       it "falls back to the global" do
-        begin
-          previous = Kasket::CONFIGURATION[:default_expires_in]
-          Kasket::CONFIGURATION[:default_expires_in] = 86401
-          assert_equal 86401, DefaultComment.kasket_ttl
-        ensure
-          Kasket::CONFIGURATION[:default_expires_in] = previous
-        end
+        previous = Kasket::CONFIGURATION[:default_expires_in]
+        Kasket::CONFIGURATION[:default_expires_in] = 86401
+        assert_equal 86401, DefaultComment.kasket_ttl
+      ensure
+        Kasket::CONFIGURATION[:default_expires_in] = previous
       end
     end
   end


### PR DESCRIPTION
## Description

Not sure why but Rubocop suddenly started breaking. This fixes most of the offenses as they are nitpicks.
I extended the maximum line length mostly because of https://github.com/zendesk/kasket/blob/master/lib/kasket/query_parser.rb#L15

Fixing rubocop was enough yak shaving for me... refactoring how we regenerate this regex will be a dragon for another person.