### PR TITLE
Add instrumentation to find_by_sql

### DIFF
--- a/lib/kasket/read_mixin.rb
+++ b/lib/kasket/read_mixin.rb
@@ -33,11 +33,18 @@ module Kasket
           find_by_sql_with_kasket_on_id_array(query[:key])
         else
           if value = Kasket.cache.read(query[:key])
-            if value.is_a?(Array)
+            result_set = if value.is_a?(Array)
               filter_pending_records(find_by_sql_with_kasket_on_id_array(value))
             else
               filter_pending_records(Array.wrap(value).collect { |record| instantiate(record.dup) })
             end
+
+            payload = {
+              record_count: result_set.length,
+              class_name: to_s
+            }
+
+            ActiveSupport::Notifications.instrument('instantiation.active_record', payload) { result_set }
           else
             store_in_kasket(query[:key], find_by_sql_without_kasket(*args))
           end


### PR DESCRIPTION
Overriding `find_by_sql` means we lose the instrumentation when queries are cached. Let's put it back.