### PR TITLE
[R5U-2250] Request for Implementation: Support for Rails >= 5.1.7 ignored_columns

### DIFF
--- a/test/fixtures/posts.yml
+++ b/test/fixtures/posts.yml
@@ -3,6 +3,7 @@ no_comments:
   blog: a_blog
   title: no_comments
   author: mick
+  ignored_column: ignored
   created_at: 2013-10-14 15:30:00
 
 has_two_comments:

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -71,6 +71,24 @@ describe Kasket::QueryParser do
       assert @parser.parse('SELECT * FROM "posts" WHERE (title = red AND blog_id = big)')
     end
 
+    it "doesn't support partial selects" do
+      assert_nil @parser.parse('SELECT `posts`.author_id FROM `posts` WHERE id = 1')
+    end
+
+    it "supports star selects" do
+      assert @parser.parse("SELECT `posts`.* FROM `posts` WHERE id = 1")
+    end
+
+    it "supports full selects" do
+      assert @parser.parse("SELECT #{Post.column_names.map { |c| "`posts`.`#{c}`" }.join ", "} FROM `posts` WHERE id = 1")
+    end
+
+    if ActiveRecord::VERSION::STRING >= '5.0.0'
+      it "doesn't support selects of ignored columns" do
+        assert_nil @parser.parse("SELECT #{(Post.column_names + Post.ignored_columns).map { |c| "`posts`.`#{c}`" }.join ", "} FROM `posts` WHERE id = 1")
+      end
+    end
+
     describe "extract options" do
       it "provide the limit" do
         assert_nil      parse(conditions: { id: 2 })[:limit]

--- a/test/read_mixin_test.rb
+++ b/test/read_mixin_test.rb
@@ -9,7 +9,7 @@ describe Kasket::ReadMixin do
       if ActiveRecord::VERSION::STRING >= '4.2.0'
         @post_database_result = {
           'id' => 1, 'title' => 'Hello', "author_id" => nil, "blog_id" => nil, "poly_id" => nil,
-          "poly_type" => nil, "created_at" => nil, "updated_at" => nil, "big_id" => nil
+          "poly_type" => nil, "created_at" => nil, "updated_at" => nil, "big_id" => nil, "ignored_column" => nil
         }
         @comment_database_result = [
           { 'id' => 1, 'body' => 'Hello', "post_id" => nil, "created_at" => nil, "updated_at" => nil, "public" => nil },
@@ -61,6 +61,7 @@ describe Kasket::ReadMixin do
 
       describe "a single record" do
         before do
+          Post.unstub(:find_by_sql_without_kasket)
           Kasket.cache.write("#{Post.kasket_key_prefix}id=1", @post_database_result)
         end
 
@@ -82,10 +83,12 @@ describe Kasket::ReadMixin do
       end
 
       describe "an array of records" do
-        let(:posts) { ["#{Post.kasket_key_prefix}id=1", "#{Post.kasket_key_prefix}id=2"] }
+        let(:comments) { ["#{Comment.kasket_key_prefix}id=1", "#{Comment.kasket_key_prefix}id=2"] }
 
         before do
-          Kasket.cache.write("#{Comment.kasket_key_prefix}post_id=1", posts)
+          Comment.unstub(:find_by_sql_without_kasket)
+          Kasket.cache.write("#{Comment.kasket_key_prefix}post_id=1", comments)
+          @comment_database_result.each { |c| Kasket.cache.write("#{Comment.kasket_key_prefix}id=#{c['id']}", c) }
         end
 
         it "does not call the db" do
@@ -137,8 +140,6 @@ describe Kasket::ReadMixin do
         end
 
         it "does not send a notification" do
-          Post.stubs(:find_by_sql_without_kasket).returns(@post_records)
-
           ActiveSupport::Notifications.subscribed(callback, 'instantiation.active_record') do
             Post.find_by_sql('SELECT * FROM `posts` WHERE (id = 1)')
           end
@@ -190,6 +191,7 @@ describe Kasket::ReadMixin do
       assert_equal(["#{Comment.kasket_key_prefix}id=1", "#{Comment.kasket_key_prefix}id=2"], stored_value)
       assert_equal(@comment_database_result, stored_value.map {|key| Kasket.cache.read(key)})
 
+      Comment.unstub(:find_by_sql_without_kasket)
       Comment.expects(:find_by_sql_without_kasket).never
       records = Comment.find_by_sql('SELECT * FROM `comments` WHERE (post_id = 1)')
       assert_equal(@comment_records, records.sort_by(&:id))

--- a/test/schema.rb
+++ b/test/schema.rb
@@ -18,6 +18,7 @@ ActiveRecord::Schema.define do
       t.string   'title'
       t.integer  'author_id'
       t.integer  'blog_id'
+      t.string   'ignored_column'
       t.integer  'poly_id'
       t.integer  'big_id', limit: 8
       t.string   'poly_type'

--- a/test/test_models.rb
+++ b/test/test_models.rb
@@ -37,6 +37,10 @@ class Post < ActiveRecord::Base
   has_kasket_on :title
   has_kasket_on :blog_id, :id
 
+  if ActiveRecord::VERSION::STRING >= '5.0.0'
+    self.ignored_columns = ["ignored_column"]
+  end
+
   def make_dirty!
     self.updated_at = Time.now
     self.class.connection.execute("UPDATE posts SET updated_at = '#{updated_at.utc.to_s(:db)}' WHERE id = #{id}")


### PR DESCRIPTION
<!-- [R5U-2250] Request for Implementation: Support for Rails >= 5.1.7 ignored_columns -->
## Description

### Request for Implementation

#### Background
@zendesk/rails-upgrade found tests failing in 5.1 when an expectation asserted on specific SQL, or kasket was used to cache on models with ignored columns. 
We discovered there is a conflict between Rails 5.1.7 and kasket, when columns are ignored (both with the rails built-in `ignored_columns`, or the zendesk database support `ignore_columns`)

After Running the test suite with an ignored column, the result is:

`97 runs, 120 assertions, 42 failures, 11 errors, 0 skips`

I believe the cause of the failures is Rails 5.1.7 added first-party support to ignore columns. Looking at the history of [build_select](https://apidock.com/rails/v5.1.7/ActiveRecord/QueryMethods/build_select) we can see in 5.1.7 we construct `SELECT` differently in the presence of ignored columns 


## References

* Jira: [R5U-2250](https://zendesk.atlassian.net/browse/R5U-2250)


<details>

<summary><h2>Extra details and notes (click to expand)</h2></summary>

## Full test output:
```
Run options: --seed 62940

# Running:

EEEEE......FF.......FFFF.F.E..EF.FF....FFFFFFFFFFF......FFFFFFFF...F...EE..E...E.FFFFFFFFFFF.....

Finished in 0.986782s, 98.2993 runs/s, 121.6074 assertions/s.

  1) Error:
Kasket::QueryParser::Parsing::key generation::when limit 1#test_0001_add /first to the key if the index does not include id:
NoMethodError: undefined method `[]' for nil:NilClass
    /kasket/test/parser_test.rb:136:in `block (5 levels) in <top (required)>'

  2) Error:
Kasket::QueryParser::Parsing::key generation::when limit 1#test_0002_not add /first to the key when the index includes id:
NoMethodError: undefined method `[]' for nil:NilClass
    /kasket/test/parser_test.rb:140:in `block (5 levels) in <top (required)>'

  3) Error:
Kasket::QueryParser::Parsing::key generation#test_0001_include the table name and version:
NoMethodError: undefined method `[]' for nil:NilClass
    /kasket/test/parser_test.rb:113:in `block (4 levels) in <top (required)>'

  4) Error:
Kasket::QueryParser::Parsing::key generation#test_0002_include all indexed attributes:
NoMethodError: undefined method `[]' for nil:NilClass
    /kasket/test/parser_test.rb:118:in `block (4 levels) in <top (required)>'

  5) Error:
Kasket::QueryParser::Parsing::key generation#test_0003_generate multiple keys on IN queries:
NoMethodError: undefined method `[]' for nil:NilClass
    /kasket/test/parser_test.rb:128:in `block (4 levels) in <top (required)>'

  6) Failure:
find some::unfound#test_0002_not ignore unfound when using find [/kasket/test/find_some_test.rb:11]:
Expected nil to be truthy.

  7) Failure:
find some::unfound#test_0001_ignore unfound when using find_all_by_id [/kasket/test/find_some_test.rb:11]:
Expected nil to be truthy.

  8) Failure:
find one#test_0005_use same scope when finding on has_many [/kasket/test/find_one_test.rb:63]:
Expected nil to be truthy.

  9) Failure:
find one#test_0004_respect scope [/kasket/test/find_one_test.rb:49]:
Expected nil to be truthy.

 10) Failure:
find one#test_0001_cache find(id) calls [/kasket/test/find_one_test.rb:12]:
Expected nil to be truthy.

 11) Failure:
find one#test_0002_only cache on indexed attributes [/kasket/test/find_one_test.rb:19]:
not all expectations were satisfied
unsatisfied expectations:
- expected exactly twice, invoked never: <#ActiveSupport::Cache::MemoryStore entries=0, size=0, options={}>.read(any_parameters)
satisfied expectations:
- expected never, invoked never: <#ActiveSupport::Cache::MemoryStore entries=0, size=0, options={}>.read(any_parameters)


 12) Failure:
find one#test_0003_not use cache when using the :select option [/kasket/test/find_one_test.rb:36]:
Expected nil to be truthy.

 13) Error:
Kasket::ReadMixin#test_0002_not store time with zone:
NoMethodError: undefined method `[]' for nil:NilClass
    /kasket/test/read_mixin_test.rb:209:in `block (3 levels) in <top (required)>'
    /.rbenv/versions/2.5.8/lib/ruby/gems/2.5.0/gems/activesupport-5.1.7/lib/active_support/core_ext/time/zones.rb:64:in `use_zone'
    /kasket/test/read_mixin_test.rb:204:in `block (2 levels) in <top (required)>'

 14) Error:
Kasket::Visitor#test_0002_builds select Bignum:
NoMethodError: undefined method `fetch' for nil:NilClass
    /kasket/test/visitor_test.rb:26:in `block (2 levels) in <top (required)>'

 15) Failure:
Kasket::Visitor#test_0004_build from Nori::StringWithAttributes [/kasket/test/visitor_test.rb:47]:
--- expected
+++ actual
@@ -1 +1 @@
-{:attributes=>[[:id, "1"]], :from=>"posts", :index=>[:id], :key=>"kasket-4/R51/posts/version=6872/id=1"}
+nil


 16) Failure:
Kasket::Visitor#test_0001_build select id [/kasket/test/visitor_test.rb:21]:
--- expected
+++ actual
@@ -1 +1 @@
-{:attributes=>[[:id, "1"]], :from=>"posts", :index=>[:id], :key=>"kasket-4/R51/posts/version=6872/id=1"}
+nil


 17) Failure:
Kasket::Visitor#test_0003_builds with nil values [/kasket/test/visitor_test.rb:37]:
--- expected
+++ actual
@@ -1 +1 @@
-{:attributes=>[[:deleted_at, nil], [:id, "1"]], :from=>"posts", :index=>[:deleted_at, :id], :key=>"kasket-4/R51/posts/version=6872/deleted_at=/id=1"}
+nil


 18) Failure:
cache expiry::a cached object#test_0003_is removed from cache when updated [/kasket/test/cache_expiry_test.rb:12]:
Expected nil to be truthy.

 19) Failure:
cache expiry::a cached object#test_0004_is removed from cache when touched [/kasket/test/cache_expiry_test.rb:12]:
Expected nil to be truthy.

 20) Failure:
cache expiry::a cached object#test_0005_loads a fresh copy when reload is called [/kasket/test/cache_expiry_test.rb:12]:
Expected nil to be truthy.

 21) Failure:
cache expiry::a cached object#test_0007_clears all indices for instance when using update_column [/kasket/test/cache_expiry_test.rb:12]:
Expected nil to be truthy.

 22) Failure:
cache expiry::a cached object#test_0006_clears all indices for instance when updated [/kasket/test/cache_expiry_test.rb:12]:
Expected nil to be truthy.

 23) Failure:
cache expiry::a cached object#test_0008_clears all indices for instance when using update_columns [/kasket/test/cache_expiry_test.rb:12]:
Expected nil to be truthy.

 24) Failure:
cache expiry::a cached object#test_0001_is removed from cache when deleted [/kasket/test/cache_expiry_test.rb:12]:
Expected nil to be truthy.

 25) Failure:
cache expiry::a cached object#test_0002_clears all indices for instance when deleted [/kasket/test/cache_expiry_test.rb:12]:
Expected nil to be truthy.

 26) Failure:
Kasket::ReadMixin::pending saved records in a transaction#test_0003_returns nothing if object destroyed [/kasket/test/read_mixin_test.rb:229]:
Expected nil to not be nil.

 27) Failure:
Kasket::ReadMixin::pending saved records in a transaction#test_0001_returns saved version [/kasket/test/read_mixin_test.rb:229]:
Expected nil to not be nil.

 28) Failure:
Kasket::ReadMixin::pending saved records in a transaction#test_0002_finds cached when searching by column [/kasket/test/read_mixin_test.rb:229]:
Expected nil to not be nil.

 29) Failure:
cache expiry::a cached object::when :write_through is true#test_0003_writes id key and clears indices for instance when updated [/kasket/test/cache_expiry_test.rb:12]:
Expected nil to be truthy.

 30) Failure:
cache expiry::a cached object::when :write_through is true#test_0001_is updated in cache when updated [/kasket/test/cache_expiry_test.rb:12]:
Expected nil to be truthy.

 31) Failure:
cache expiry::a cached object::when :write_through is true#test_0002_is updated in cache when touched [/kasket/test/cache_expiry_test.rb:12]:
Expected nil to be truthy.

 32) Failure:
dirty#test_0005_supports blocks [/kasket/test/dirty_test.rb:36]:
Expected nil to be truthy.

 33) Failure:
dirty#test_0001_clear the indices when a dirty method is called [/kasket/test/dirty_test.rb:19]:
Expected nil to be truthy.

 34) Failure:
dirty#test_0002_clears the indices when touch is called [/kasket/test/dirty_test.rb:23]:
Expected nil to be truthy.

 35) Failure:
dirty#test_0003_clear the indices when update_column is called [/kasket/test/dirty_test.rb:27]:
Expected nil to be truthy.

 36) Failure:
dirty#test_0004_clear the indices when update_attribute is called [/kasket/test/dirty_test.rb:31]:
Expected nil to be truthy.

 37) Failure:
Kasket::QueryParser::Parsing#test_0009_support cachable queries [/kasket/test/parser_test.rb:58]:
Expected nil to be truthy.

 38) Error:
Kasket::QueryParser::Parsing#test_0005_extract conditions:
NoMethodError: undefined method `[]' for nil:NilClass
    /kasket/test/parser_test.rb:41:in `block (3 levels) in <top (required)>'

 39) Error:
Kasket::QueryParser::Parsing#test_0010_support IN queries on id:
NoMethodError: undefined method `[]' for nil:NilClass
    /kasket/test/parser_test.rb:63:in `block (3 levels) in <top (required)>'

 40) Error:
Kasket::QueryParser::Parsing#test_0007_extract required index:
NoMethodError: undefined method `[]' for nil:NilClass
    /kasket/test/parser_test.rb:50:in `block (3 levels) in <top (required)>'

 41) Error:
Kasket::QueryParser::Parsing::extract options#test_0001_provide the limit:
NoMethodError: undefined method `[]' for nil:NilClass
    /kasket/test/parser_test.rb:76:in `block (4 levels) in <top (required)>'

 42) Failure:
cacheable::caching of results of find::with just one result#test_0001_write result in cache if it is kasket_cacheable? [/kasket/test/cacheable_test.rb:32]:
not all expectations were satisfied
unsatisfied expectations:
- expected exactly once, invoked never: #<AnyInstance:Post(id: integer, title: string, author_id: integer, blog_id: integer, poly_id: integer, big_id: integer, poly_type: string, created_at: datetime, updated_at: datetime)>.kasket_cacheable?(any_parameters)
- expected exactly once, invoked never: <#ActiveSupport::Cache::MemoryStore entries=0, size=0, options={}>.write(any_parameters)
satisfied expectations:
- allowed any number of times, invoked once: Post(id: integer, title: string, author_id: integer, blog_id: integer, poly_id: integer, big_id: integer, poly_type: string, created_at: datetime, updated_at: datetime).find_by_sql_without_kasket(any_parameters)
- allowed any number of times, invoked never: Comment(id: integer, body: text, post_id: integer, public: boolean, created_at: datetime, updated_at: datetime).find_by_sql_without_kasket(any_parameters)


 43) Failure:
cacheable::caching of results of find::with just one result#test_0002_not write result in cache if it is not kasket_cacheable? [/kasket/test/cacheable_test.rb:38]:
not all expectations were satisfied
unsatisfied expectations:
- expected exactly once, invoked never: #<AnyInstance:Post(id: integer, title: string, author_id: integer, blog_id: integer, poly_id: integer, big_id: integer, poly_type: string, created_at: datetime, updated_at: datetime)>.kasket_cacheable?(any_parameters)
satisfied expectations:
- allowed any number of times, invoked once: Post(id: integer, title: string, author_id: integer, blog_id: integer, poly_id: integer, big_id: integer, poly_type: string, created_at: datetime, updated_at: datetime).find_by_sql_without_kasket(any_parameters)
- allowed any number of times, invoked never: Comment(id: integer, body: text, post_id: integer, public: boolean, created_at: datetime, updated_at: datetime).find_by_sql_without_kasket(any_parameters)
- expected never, invoked never: <#ActiveSupport::Cache::MemoryStore entries=0, size=0, options={}>.write(any_parameters)


 44) Failure:
find some#test_0003_use cache for find(id, id) calls with string values [/kasket/test/find_some_test.rb:11]:
Expected nil to be truthy.

 45) Failure:
find some#test_0009_does not raise error when cache is poisoned with TrueClass [/kasket/test/find_some_test.rb:11]:
Expected nil to be truthy.

 46) Failure:
find some#test_0001_use cache for find(id, id) calls [/kasket/test/find_some_test.rb:11]:
Expected nil to be truthy.

 47) Failure:
find some#test_0008_only lookup the records that are not in the cache [/kasket/test/find_some_test.rb:11]:
Expected nil to be truthy.

 48) Failure:
find some#test_0004_use cache for find([id, id]) calls with string values [/kasket/test/find_some_test.rb:11]:
Expected nil to be truthy.

 49) Failure:
find some#test_0005_use cache for where :id => xxx calls [/kasket/test/find_some_test.rb:11]:
Expected nil to be truthy.

 50) Failure:
find some#test_0007_cache when found using find(id, id) calls [/kasket/test/find_some_test.rb:11]:
Expected nil to be truthy.

 51) Failure:
find some#test_0002_use cache for find([id, id]) calls [/kasket/test/find_some_test.rb:11]:
Expected nil to be truthy.

 52) Failure:
find some#test_0006_use cache for where :id => xxx calls with string values [/kasket/test/find_some_test.rb:11]:
Expected nil to be truthy.

97 runs, 120 assertions, 41 failures, 11 errors, 0 skips
```


</details>
