### PR TITLE
[CCORE-371] Fall back to database on 'multi_response has completed' RuntimeError

### DIFF
--- a/lib/kasket/read_mixin.rb
+++ b/lib/kasket/read_mixin.rb
@@ -64,11 +64,23 @@ module Kasket
     end
 
     def find_by_sql_with_kasket_on_id_array(keys)
-      key_attributes_map = Kasket.cache.read_multi(*keys)
-
-      found_keys, missing_keys = keys.partition {|k| key_attributes_map[k] }
-      found_keys.each {|k| key_attributes_map[k] = instantiate(key_attributes_map[k].dup) }
-      key_attributes_map.merge!(missing_records_from_db(missing_keys))
+      begin
+        key_attributes_map = Kasket.cache.read_multi(*keys)
+      rescue RuntimeError => e
+        # Elasticache Memcached has a bug where it returns a 0x00 binary protocol response with no data
+        # during a reboot, causing the Dalli memcached client to throw a RuntimeError during a multi get
+        # (https://github.com/petergoldstein/dalli/blob/v2.7.7/lib/dalli/server.rb#L148).
+        # Fall back to the database when this happens.
+        if e.message == "multi_response has completed"
+          key_attributes_map = missing_records_from_db(keys)
+        else
+          raise
+        end
+      else
+        found_keys, missing_keys = keys.partition {|k| key_attributes_map[k] }
+        found_keys.each {|k| key_attributes_map[k] = instantiate(key_attributes_map[k].dup) }
+        key_attributes_map.merge!(missing_records_from_db(missing_keys))
+      end
 
       key_attributes_map.values.compact
     end

--- a/test/read_mixin_test.rb
+++ b/test/read_mixin_test.rb
@@ -103,6 +103,30 @@ describe Kasket::ReadMixin do
           assert_equal 2, @record_count
           assert_equal "Comment", @class_name
         end
+
+        describe "when read_multi raises a RuntimeError with 'multi_response has completed'" do
+          before do
+            Kasket.cache.stubs(:read_multi).raises(RuntimeError.new("multi_response has completed"))
+          end
+
+          it "calls the db" do
+            Comment.expects(:find_by_sql_without_kasket).once.returns(@comment_records)
+
+            Comment.find_by_sql('SELECT * FROM `comments` WHERE (post_id = 1)')
+          end
+        end
+
+        describe "when read_multi raises a RuntimeError with some other message" do
+          before do
+            Kasket.cache.stubs(:read_multi).raises(RuntimeError.new("good news everyone"))
+          end
+
+          it "re-raises the exception" do
+            assert_raises RuntimeError do
+              Comment.find_by_sql('SELECT * FROM `comments` WHERE (post_id = 1)')
+            end
+          end
+        end
       end
 
       describe "a cache miss" do


### PR DESCRIPTION
Elasticache Memcached has a bug where it returns a 0x00 binary protocol response with no data during a reboot. This confuses the Dalli memcached client when it does a multi get, causing it to throw a RuntimeError (https://github.com/petergoldstein/dalli/blob/v2.7.7/lib/dalli/server.rb#L148).

Fall back to the database when this happens.