### PR TITLE
[CCORE-371] Handle all of the exceptions defined by Dalli and fallback to DB if any are encountered

### DIFF
--- a/lib/kasket/read_mixin.rb
+++ b/lib/kasket/read_mixin.rb
@@ -66,6 +66,8 @@ module Kasket
     def find_by_sql_with_kasket_on_id_array(keys)
       begin
         key_attributes_map = Kasket.cache.read_multi(*keys)
+      rescue Dalli::DalliError, Dalli::MarshalError, Dalli::NetworkError, Dalli::RingError, Dalli::UnmarshalError, Dalli::ValueOverMaxSize
+        key_attributes_map = missing_records_from_db(keys)
       rescue RuntimeError => e
         # Elasticache Memcached has a bug where it returns a 0x00 binary protocol response with no data
         # during a reboot, causing the Dalli memcached client to throw a RuntimeError during a multi get

--- a/lib/kasket/read_mixin.rb
+++ b/lib/kasket/read_mixin.rb
@@ -66,7 +66,7 @@ module Kasket
     def find_by_sql_with_kasket_on_id_array(keys)
       begin
         key_attributes_map = Kasket.cache.read_multi(*keys)
-      rescue Dalli::DalliError, Dalli::MarshalError, Dalli::NetworkError, Dalli::RingError, Dalli::UnmarshalError, Dalli::ValueOverMaxSize
+      rescue Dalli::DalliError, Dalli::ValueOverMaxSize
         key_attributes_map = missing_records_from_db(keys)
       rescue RuntimeError => e
         # Elasticache Memcached has a bug where it returns a 0x00 binary protocol response with no data


### PR DESCRIPTION
The way find_by_sql_with_kasket_on_id_array was originally implemented did not gracefully handle any exceptions when using memcached as an external shared cache provider.

There is a small list of exceptions that the Dalli library can generate, so we would like to rescue on those exceptions specifically and fallback to the database if they are encountered.

The expectation would be that when using any other local cache provider like a MemoryStore or FileStore there would not be the same vectors or frequency of exceptions to occur.  There may be room to optimize this down the road to handle other specific errors from the ActiveSupport MemCacheStore or RedisCacheStore, but we don't need to worry about those today.