### PR TITLE
Revert "[CCORE-371] Fall back to database on 'multi_response has completed' RuntimeError"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Kasket [![Build status](https://circleci.com/gh/zendesk/kasket.svg?style=svg)](https://circleci.com/gh/zendesk/kasket)
+# Kasket
 
 ### Puts a cap on your queries
 A caching layer for ActiveRecord (3.x and 4.x)

--- a/test/read_mixin_test.rb
+++ b/test/read_mixin_test.rb
@@ -103,30 +103,6 @@ describe Kasket::ReadMixin do
           assert_equal 2, @record_count
           assert_equal "Comment", @class_name
         end
-
-        describe "when read_multi raises a RuntimeError with 'multi_response has completed'" do
-          before do
-            Kasket.cache.stubs(:read_multi).raises(RuntimeError.new("multi_response has completed"))
-          end
-
-          it "calls the db" do
-            Comment.expects(:find_by_sql_without_kasket).once.returns(@comment_records)
-
-            Comment.find_by_sql('SELECT * FROM `comments` WHERE (post_id = 1)')
-          end
-        end
-
-        describe "when read_multi raises a RuntimeError with some other message" do
-          before do
-            Kasket.cache.stubs(:read_multi).raises(RuntimeError.new("good news everyone"))
-          end
-
-          it "re-raises the exception" do
-            assert_raises RuntimeError do
-              Comment.find_by_sql('SELECT * FROM `comments` WHERE (post_id = 1)')
-            end
-          end
-        end
       end
 
       describe "a cache miss" do


### PR DESCRIPTION
* Reverts zendesk/kasket#66
* This did not properly fix the issue anyway as the next request using the dalli client would end up with a corrupt response and fail.
* The proper fix was added in https://github.com/petergoldstein/dalli/pull/783
* The error also seems to have gone away so maybe Elasticache fixed the issue...?