### PR TITLE
[ R5U-2786] Onboards Kasket to Ruby Gems Workflow

### DIFF
--- a/.github/workflows/ruby-gem-publication.yml
+++ b/.github/workflows/ruby-gem-publication.yml
@@ -1,0 +1,12 @@
+name: Ruby Gem Publish
+
+on:
+  push:
+    tags: v*
+
+jobs:
+  call-workflow:
+    uses: zendesk/gw/.github/workflows/ruby-gem-publication.yml@main
+    secrets:
+      RUBY_GEMS_API_KEY: ${{ secrets.RUBY_GEMS_API_KEY }}
+      RUBY_GEMS_TOTP_DEVICE: ${{ secrets.RUBY_GEMS_TOTP_DEVICE }}


### PR DESCRIPTION
The Ruby Gems Workflow automates publishing your Gem to RubyGems when a commit is tagged with something beginning with v.

Gem Owners:  Please validate that Kasket has an environment called rubygems-publish with either 1) Required reviewers or 2) Deployment branches.  This is a[ prerequisite to onboarding Kasket to the Ruby Gems Workflow](https://zendesk.atlassian.net/wiki/spaces/BRE/pages/5443454171/Ruby+Gems+Workflow+Onboarding) and requires admin status to verify(which I do not have). 