### PR TITLE
Drop support for Rails 4.2 and 5.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,21 +17,14 @@ jobs:
           - 2.6
           - 2.7
         gemfile:
-          - gemfiles/rails4.2.gemfile
-          - gemfiles/rails5.0.gemfile
           - gemfiles/rails5.1.gemfile
           - gemfiles/rails5.2.gemfile
           - gemfiles/rails6.0.gemfile
           - gemfiles/rails6.1.gemfile
-        exclude:
-          - ruby: 2.7
-            gemfile: gemfiles/rails4.2.gemfile
-          - ruby: 2.7
-            gemfile: gemfiles/rails5.0.gemfile
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
     steps:
-      - uses: zendesk/checkout@v2
+      - uses: zendesk/checkout@v3
       - uses: zendesk/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ require:
 
 AllCops:
   DisplayCopNames: true
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6
   NewCops: enable
   Exclude:
     - vendor/**/*

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Kasket
 
 ### Puts a cap on your queries
-A caching layer for ActiveRecord (3.x and 4.x)
+A caching layer for ActiveRecord.
 
 Developed and used by [Zendesk](http://zendesk.com).
 

--- a/gemfiles/rails4.2.gemfile
+++ b/gemfiles/rails4.2.gemfile
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-eval_gemfile('./common.rb')
-
-gem 'activerecord', '~> 4.2'
-gem 'test_after_commit', '~> 1.1.0'

--- a/gemfiles/rails5.0.gemfile
+++ b/gemfiles/rails5.0.gemfile
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-eval_gemfile('./common.rb')
-
-gem 'activerecord', '~> 5.0.0'

--- a/kasket.gemspec
+++ b/kasket.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.license     = "Apache License Version 2.0"
   s.files       = Dir.glob("lib/**/*") + %w[README.md]
 
-  s.required_ruby_version = '>= 2.5.0'
+  s.required_ruby_version = '>= 2.6.0'
 
-  s.add_runtime_dependency("activerecord", ">= 4.2", "< 7")
+  s.add_runtime_dependency("activerecord", ">= 5.1", "< 7")
 end

--- a/lib/kasket.rb
+++ b/lib/kasket.rb
@@ -31,11 +31,8 @@ module Kasket
     CONFIGURATION[:default_expires_in]  = options[:default_expires_in]  if options[:default_expires_in]
 
     ActiveRecord::Base.extend(Kasket::ConfigurationMixin)
-
-    if defined?(ActiveRecord::Relation)
-      ActiveRecord::Relation.include Kasket::RelationMixin
-      Arel::SelectManager.include Kasket::SelectManagerMixin
-    end
+    ActiveRecord::Relation.include(Kasket::RelationMixin)
+    Arel::SelectManager.include(Kasket::SelectManagerMixin)
   end
 
   def self.cache_store=(options)

--- a/lib/kasket/configuration_mixin.rb
+++ b/lib/kasket/configuration_mixin.rb
@@ -101,16 +101,8 @@ module Kasket
     def kasket_quoted_value_for_column(value, column)
       if column
         conn = connection
-        casted_value =
-          case ActiveRecord::VERSION::MAJOR
-          when 3 then column.type_cast(value)
-          when 4 then column.type_cast_for_database(value)
-          when 5, 6
-            type = conn.lookup_cast_type_from_column(column)
-            conn.type_cast(type.serialize(value))
-          else
-            raise NotImplementedError, "Unsupported: #{ActiveRecord::VERSION}"
-          end
+        type = conn.lookup_cast_type_from_column(column)
+        casted_value = conn.type_cast(type.serialize(value))
         conn.quote(casted_value).downcase
       else
         value.to_s

--- a/lib/kasket/read_mixin.rb
+++ b/lib/kasket/read_mixin.rb
@@ -14,14 +14,10 @@ module Kasket
 
       if use_kasket?
         query = if sql.respond_to?(:to_kasket_query)
-          if ActiveRecord::VERSION::MAJOR < 5
-            sql.to_kasket_query(self, args[1])
+          if ActiveRecord::VERSION::STRING < '5.2'
+            sql.to_kasket_query(self, args[1].map(&:value_for_database))
           else
-            if ActiveRecord::VERSION::STRING < '5.2'
-              sql.to_kasket_query(self, args[1].map(&:value_for_database))
-            else
-              sql.to_kasket_query(self)
-            end
+            sql.to_kasket_query(self)
           end
         else
           kasket_parser.parse(sanitize_sql(sql))

--- a/lib/kasket/relation_mixin.rb
+++ b/lib/kasket/relation_mixin.rb
@@ -1,12 +1,9 @@
 # frozen_string_literal: true
 module Kasket
   module RelationMixin
-    # binds can be removed when support for Rails < 5 is removed
-    def to_kasket_query(binds = nil)
+    def to_kasket_query
       if arel.is_a?(Arel::SelectManager)
-        if ActiveRecord::VERSION::MAJOR < 5
-          arel.to_kasket_query(klass, (binds || bind_values))
-        elsif ActiveRecord::VERSION::STRING < '5.2'
+        if ActiveRecord::VERSION::STRING < '5.2'
           arel.to_kasket_query(klass, (@values[:where].to_h.values + Array(@values[:limit])))
         else
           arel.to_kasket_query(klass)

--- a/lib/kasket/visitor.rb
+++ b/lib/kasket/visitor.rb
@@ -49,7 +49,7 @@ module Kasket
 
     def visit_Arel_Nodes_SelectCore(node, *_)
       return :unsupported if node.groups.any?
-      return :unsupported if ActiveRecord::VERSION::MAJOR < 5 ? node.having : node.havings.present?
+      return :unsupported if node.havings.present?
       return :unsupported if node.set_quantifier
       return :unsupported if !node.source || node.source.empty?
       return :unsupported if node.projections.empty?
@@ -81,11 +81,7 @@ module Kasket
     end
 
     def visit_Arel_Nodes_Limit(node, *_)
-      if ActiveRecord::VERSION::MAJOR < 5
-        { limit: node.value.to_i }
-      else
-        { limit: visit(node.value).to_i }
-      end
+      { limit: visit(node.value).to_i }
     end
 
     def visit_Arel_Nodes_JoinSource(node, *_)
@@ -144,14 +140,10 @@ module Kasket
     end
 
     def visit_Arel_Nodes_BindParam(node, *_)
-      if ActiveRecord::VERSION::MAJOR < 5
-        visit(@binds.shift[1])
+      if ActiveRecord::VERSION::STRING < '5.2'
+        visit(@binds.shift)
       else
-        if ActiveRecord::VERSION::STRING < '5.2'
-          visit(@binds.shift)
-        else
-          visit(node.value.value) unless node.value.value.nil?
-        end
+        visit(node.value.value) unless node.value.value.nil?
       end
     end
 

--- a/test/cache_expiry_test.rb
+++ b/test/cache_expiry_test.rb
@@ -65,17 +65,15 @@ describe "cache expiry" do
       @post.update_column :title, "new_title"
     end
 
-    if ActiveRecord::VERSION::MAJOR >= 4
-      it "clears all indices for instance when using update_columns" do
-        Kasket.cache.expects(:delete).with(Post.kasket_key_prefix + "id=#{@post.id}")
-        Kasket.cache.expects(:delete).with(Post.kasket_key_prefix + "title='#{@post.title}'")
-        Kasket.cache.expects(:delete).with(Post.kasket_key_prefix + "title='#{@post.title}'/first")
-        Kasket.cache.expects(:delete).with(Post.kasket_key_prefix + "title='new_title'")
-        Kasket.cache.expects(:delete).with(Post.kasket_key_prefix + "title='new_title'/first")
-        Kasket.cache.expects(:delete).with(Post.kasket_key_prefix + "blog_id=#{@post.blog_id}/id=#{@post.id}")
+    it "clears all indices for instance when using update_columns" do
+      Kasket.cache.expects(:delete).with(Post.kasket_key_prefix + "id=#{@post.id}")
+      Kasket.cache.expects(:delete).with(Post.kasket_key_prefix + "title='#{@post.title}'")
+      Kasket.cache.expects(:delete).with(Post.kasket_key_prefix + "title='#{@post.title}'/first")
+      Kasket.cache.expects(:delete).with(Post.kasket_key_prefix + "title='new_title'")
+      Kasket.cache.expects(:delete).with(Post.kasket_key_prefix + "title='new_title'/first")
+      Kasket.cache.expects(:delete).with(Post.kasket_key_prefix + "blog_id=#{@post.blog_id}/id=#{@post.id}")
 
-        @post.update_columns title: "new_title"
-      end
+      @post.update_columns title: "new_title"
     end
 
     describe "when :write_through is true" do

--- a/test/find_one_test.rb
+++ b/test/find_one_test.rb
@@ -58,14 +58,12 @@ describe "find one" do
     assert_key post.kasket_key
   end
 
-  if ActiveRecord::VERSION::STRING >= '5.0.0'
-    it "doesn't use cache when using the :select option with all columns including ignored columns" do
-      post = Post.first
-      refute_key post.kasket_key
+  it "doesn't use cache when using the :select option with all columns including ignored columns" do
+    post = Post.first
+    refute_key post.kasket_key
 
-      Post.select(Post.column_names + Post.ignored_columns).find(post.id)
-      refute_key post.kasket_key
-    end
+    Post.select(Post.column_names + Post.ignored_columns).find(post.id)
+    refute_key post.kasket_key
   end
 
   it "respect scope" do

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -11,19 +11,12 @@ ENV['TZ'] = 'UTC'
 ActiveRecord::Base.time_zone_aware_attributes = true
 ActiveRecord::Base.logger = Logger.new(StringIO.new)
 
-if ActiveRecord::VERSION::MAJOR < 5
-  if ActiveRecord::Base.respond_to?(:raise_in_transactional_callbacks)
-    ActiveRecord::Base.raise_in_transactional_callbacks = true
-  end
-  require 'test_after_commit'
-end
-
 require 'active_record/fixtures'
 require 'kasket'
 
 Kasket.setup
 
-ActiveSupport.test_order = :random if ActiveSupport.respond_to?(:test_order=)
+ActiveSupport.test_order = :random
 
 class ActiveSupport::TestCase
   # all tests inherit from this
@@ -42,12 +35,7 @@ class ActiveSupport::TestCase
     end
   end
 
-  if respond_to?(:use_transactional_tests=)
-    self.use_transactional_tests = true
-  else
-    self.use_transactional_fixtures = true
-  end
-
+  self.use_transactional_tests = true
   self.use_instantiated_fixtures = false
 
   setup :clear_cache

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -83,10 +83,8 @@ describe Kasket::QueryParser do
       assert @parser.parse("SELECT #{Post.column_names.map { |c| "`posts`.`#{c}`" }.join ", "} FROM `posts` WHERE id = 1")
     end
 
-    if ActiveRecord::VERSION::STRING >= '5.0.0'
-      it "doesn't support selects of ignored columns" do
-        assert_nil @parser.parse("SELECT #{(Post.column_names + Post.ignored_columns).map { |c| "`posts`.`#{c}`" }.join ", "} FROM `posts` WHERE id = 1")
-      end
+    it "doesn't support selects of ignored columns" do
+      assert_nil @parser.parse("SELECT #{(Post.column_names + Post.ignored_columns).map { |c| "`posts`.`#{c}`" }.join ", "} FROM `posts` WHERE id = 1")
     end
 
     describe "extract options" do

--- a/test/read_mixin_test.rb
+++ b/test/read_mixin_test.rb
@@ -6,22 +6,14 @@ describe Kasket::ReadMixin do
 
   describe "find by sql with kasket" do
     before do
-      if ActiveRecord::VERSION::STRING >= '4.2.0'
-        @post_database_result = {
-          'id' => 1, 'title' => 'Hello', "author_id" => nil, "blog_id" => nil, "poly_id" => nil,
-          "poly_type" => nil, "created_at" => nil, "updated_at" => nil, "big_id" => nil, "ignored_column" => nil
-        }
-        @comment_database_result = [
-          { 'id' => 1, 'body' => 'Hello', "post_id" => nil, "created_at" => nil, "updated_at" => nil, "public" => nil },
-          { 'id' => 2, 'body' => 'World', "post_id" => nil, "created_at" => nil, "updated_at" => nil, "public" => nil }
-        ]
-      else
-        @post_database_result = { 'id' => 1, 'title' => 'Hello' }
-        @comment_database_result = [
-          { 'id' => 1, 'body' => 'Hello' },
-          { 'id' => 2, 'body' => 'World' }
-        ]
-      end
+      @post_database_result = {
+        'id' => 1, 'title' => 'Hello', "author_id" => nil, "blog_id" => nil, "poly_id" => nil,
+        "poly_type" => nil, "created_at" => nil, "updated_at" => nil, "big_id" => nil, "ignored_column" => nil
+      }
+      @comment_database_result = [
+        { 'id' => 1, 'body' => 'Hello', "post_id" => nil, "created_at" => nil, "updated_at" => nil, "public" => nil },
+        { 'id' => 2, 'body' => 'World', "post_id" => nil, "created_at" => nil, "updated_at" => nil, "public" => nil }
+      ]
 
       @post_records = [Post.send(:instantiate, @post_database_result)]
       Post.stubs(:find_by_sql_without_kasket).returns(@post_records)

--- a/test/test_models.rb
+++ b/test/test_models.rb
@@ -47,9 +47,7 @@ class Post < ActiveRecord::Base
   has_kasket_on :title
   has_kasket_on :blog_id, :id
 
-  if ActiveRecord::VERSION::STRING >= '5.0.0'
-    self.ignored_columns = ["ignored_column"]
-  end
+  self.ignored_columns = ["ignored_column"]
 
   def make_dirty!
     self.updated_at = Time.now


### PR DESCRIPTION
Removing support for Rails 4.2 and 5.0 allows us to clean up a lot of code.