### PR TITLE
Fix for stale cache reads with multiple record IDs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,10 @@ tmtags
 ## PROJECT::GENERAL
 coverage
 rdoc
+.yardoc
 pkg
 .rvmrc
+.bundle
 Gemfile.lock
 .rbx
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,20 @@ Absolutely, but Cache Money does so much more.
 * The Cache Money code is overly complex.
 * Cache Money seems abandoned.
 
+## Development
+
+Run the tests with:
+
+```
+$ rake test
+```
+
+Access a dev console running on the local test DB:
+
+```
+$ bin/console
+```
+
 ## Note on Patches/Pull Requests
 
 * Fork the project.

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,26 @@
+#!/usr/bin/env ruby
+
+# frozen_string_literal: true
+
+# A dev-test console.
+#
+# Usage:
+#    bin/console
+
+require "bundler/setup"
+require "kasket"
+
+# Use the test setup to access the test DB and its data.
+require_relative "../test/helper"
+
+# Seed some records from the fixtures.
+ActiveRecord::FixtureSet.create_fixtures(
+  File.expand_path("../test/fixtures", __dir__),
+  %w[authors blogs posts comments]
+)
+
+# Clean state.
+Kasket.cache.clear
+
+require "pry"
+Pry.start

--- a/lib/kasket/read_mixin.rb
+++ b/lib/kasket/read_mixin.rb
@@ -26,7 +26,7 @@ module Kasket
 
       if query && has_kasket_index_on?(query[:index])
         if query[:key].is_a?(Array)
-          find_by_sql_with_kasket_on_id_array(query[:key])
+          filter_pending_records(find_by_sql_with_kasket_on_id_array(query[:key]))
         else
           if value = Kasket.cache.read(query[:key])
             # Identified a specific edge case where memcached server returns 0x00 binary protocol response with no data

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -27,14 +27,6 @@ class ActiveSupport::TestCase
   self.fixture_path = File.dirname(__FILE__) + "/fixtures/"
   fixtures :all
 
-  def create_fixtures(*table_names)
-    if block_given?
-      Fixtures.create_fixtures(Test::Unit::TestCase.fixture_path, table_names) { yield }
-    else
-      Fixtures.create_fixtures(Test::Unit::TestCase.fixture_path, table_names)
-    end
-  end
-
   self.use_transactional_tests = true
   self.use_instantiated_fixtures = false
 

--- a/test/read_mixin_test.rb
+++ b/test/read_mixin_test.rb
@@ -4,20 +4,22 @@ require_relative "helper"
 describe Kasket::ReadMixin do
   fixtures :authors
 
+  before do
+    @post_database_result = {
+      'id' => 1, 'title' => 'Hello', "author_id" => nil, "blog_id" => nil, "poly_id" => nil,
+      "poly_type" => nil, "created_at" => nil, "updated_at" => nil, "big_id" => nil, "ignored_column" => nil
+    }
+    @comment_database_result = [
+      { 'id' => 1, 'body' => 'Hello', "post_id" => 1, "created_at" => nil, "updated_at" => nil, "public" => nil },
+      { 'id' => 2, 'body' => 'World', "post_id" => 1, "created_at" => nil, "updated_at" => nil, "public" => nil }
+    ]
+    @post_records = [Post.send(:instantiate, @post_database_result)]
+    @comment_records = @comment_database_result.map {|r| Comment.send(:instantiate, r)}
+  end
+
   describe "find by sql with kasket" do
     before do
-      @post_database_result = {
-        'id' => 1, 'title' => 'Hello', "author_id" => nil, "blog_id" => nil, "poly_id" => nil,
-        "poly_type" => nil, "created_at" => nil, "updated_at" => nil, "big_id" => nil, "ignored_column" => nil
-      }
-      @comment_database_result = [
-        { 'id' => 1, 'body' => 'Hello', "post_id" => 1, "created_at" => nil, "updated_at" => nil, "public" => nil },
-        { 'id' => 2, 'body' => 'World', "post_id" => 1, "created_at" => nil, "updated_at" => nil, "public" => nil }
-      ]
-
-      @post_records = [Post.send(:instantiate, @post_database_result)]
       Post.stubs(:find_by_sql_without_kasket).returns(@post_records)
-      @comment_records = @comment_database_result.map {|r| Comment.send(:instantiate, r)}
       Comment.stubs(:find_by_sql_without_kasket).returns(@comment_records)
     end
 
@@ -302,6 +304,47 @@ describe Kasket::ReadMixin do
         assert_equal [], Post.where(id: @post.id)
         assert_nil Post.all.detect { |x| x.id == @post.id }
         assert_equal [], Post.find_by_sql("SELECT * FROM `posts` WHERE id = 1")
+      end
+    end
+
+    describe "when finding multiple records (Kasket query[:key] is an Array)" do
+      before do
+        Kasket.cache.write("#{Comment.kasket_key_prefix}id=1", @comment_database_result[0])
+        Kasket.cache.write("#{Comment.kasket_key_prefix}id=2", @comment_database_result[1])
+
+        Kasket.cache.write("#{Comment.kasket_key_prefix}post_id=1", [
+          "#{Comment.kasket_key_prefix}id=1",
+          "#{Comment.kasket_key_prefix}id=2"
+        ])
+
+        @comment = @comment_records[0]
+      end
+
+      it "returns the saved version" do
+        ActiveRecord::Base.transaction do
+          @comment.body = "new body"
+          @comment.save!
+
+          assert_equal "new body", Comment.find(1, 2)[0].body
+          assert_equal "new body", Comment.where(id: [1, 2]).to_a[0].body
+          assert_equal "new body", Comment.where(post_id: 1).to_a[0].body
+        end
+      end
+
+      it "returns nothing if object destroyed" do
+        ActiveRecord::Base.transaction do
+          @comment.destroy
+
+          assert_raises ActiveRecord::RecordNotFound do
+            Comment.find(1, 2)
+          end
+
+          assert_equal 1, Comment.where(id: [1, 2]).to_a.length
+          refute_equal @comment.id, Comment.where(id: [1, 2]).to_a[0]
+
+          assert_equal 1, Comment.where(post_id: 1).to_a.length
+          refute_equal @comment.id, Comment.where(post_id: 1).to_a[0]
+        end
       end
     end
   end

--- a/test/read_mixin_test.rb
+++ b/test/read_mixin_test.rb
@@ -36,9 +36,6 @@ describe Kasket::ReadMixin do
 
     describe "it can retrieve one or multiple records through the high-level AR model API (Kasket query[:key] is an Array)" do
       before do
-        # Actually go to the DB.
-        Comment.unstub(:find_by_sql_without_kasket)
-
         Kasket.cache.write("#{Comment.kasket_key_prefix}id=1", @comment_database_result[0])
         Kasket.cache.write("#{Comment.kasket_key_prefix}id=2", @comment_database_result[1])
 


### PR DESCRIPTION
This PR is a fix for mid-transactions stale cache reads where the query is trying to access multiple records.
It's a follow up to https://github.com/zendesk/kasket/pull/31, where I believe one code-path had been forgotten.

The PR also contains a bit of clean up in the test setup (old lines that were not used today, and could not be run with recent versions of ActiveRecord), and introduces a dev console script to make it easier to work locally.