### PR TITLE
Support for an events callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,16 @@ semantics instead. In this mode, the model will be updated in the cache as well 
 Kasket.setup(write_through: true)
 ```
 
+#### Events Callback
+
+You can configure a callable object to listen to events, e.g. `cache_hit`. This can be useful to emit metrics and observe Kasket's behaviour.
+
+```ruby
+Kasket.setup(events_callback: -> (event, ar_klass) do
+  MyMetrics.increase_some_counter("kasket.#{event}", tags: ["table:#{ar_klass.table_name}"])
+end)
+```
+
 ## Configuring caching of your models
 
 You can configure Kasket for any ActiveRecord model, and subclasses will automatically inherit the caching

--- a/README.md
+++ b/README.md
@@ -50,13 +50,16 @@ Kasket.setup(write_through: true)
 
 #### Events Callback
 
-You can configure a callable object to listen to events, e.g. `cache_hit`. This can be useful to emit metrics and observe Kasket's behaviour.
+You can configure a callable object to listen to events. This can be useful to emit metrics and observe Kasket's behaviour.
 
 ```ruby
 Kasket.setup(events_callback: -> (event, ar_klass) do
   MyMetrics.increase_some_counter("kasket.#{event}", tags: ["table:#{ar_klass.table_name}"])
 end)
 ```
+
+The following events are emitted:
+* `"cache_hit"`, when Kasket has found some record's data in the cache, which can be returned.
 
 ## Configuring caching of your models
 

--- a/gemfiles/common.rb
+++ b/gemfiles/common.rb
@@ -6,7 +6,7 @@ gem "pry",         "~> 0.13.1"
 gem "byebug",      "~> 11.1"
 gem "pry-byebug",  "= 3.9.0"
 gem "bump",        "~> 0.10"
-gem "minitest",    "~> 5.1"
+gem "minitest",    "~> 5.16.2" # temporary evil until https://github.com/zendesk/kasket/pull/82
 gem "minitest-rg", "~> 5.2"
 gem "mocha",       "~> 1.13"
 gem "rake",        "~> 13"

--- a/lib/kasket.rb
+++ b/lib/kasket.rb
@@ -18,17 +18,30 @@ module Kasket
   CONFIGURATION = { # rubocop:disable Style/MutableConstant
     max_collection_size: 100,
     write_through: false,
-    default_expires_in: nil
+    default_expires_in: nil,
+    events_callback: nil,
   }
 
   module_function
 
+  # Configure Kasket.
+  #
+  # @param [Hash] options the configuration options for Kasket.
+  # @option options [Integer] :max_collection_size max size limit for a cacheable
+  #   collection of records.
+  # @option options [Boolean] :write_through
+  # @option options [Integer, nil] :default_expires_in the cache TTL.
+  # @option options [#call] :events_callback a callable object used to instrument
+  #   Kasket operations. It is invoked with two arguments: the name of the event,
+  #   as a String, and the Klass of the ActiveRecord model the event is about.
+  #
   def setup(options = {})
     return if ActiveRecord::Base.respond_to?(:has_kasket)
 
     CONFIGURATION[:max_collection_size] = options[:max_collection_size] if options[:max_collection_size]
     CONFIGURATION[:write_through]       = options[:write_through]       if options[:write_through]
     CONFIGURATION[:default_expires_in]  = options[:default_expires_in]  if options[:default_expires_in]
+    CONFIGURATION[:events_callback]     = options[:events_callback]     if options[:events_callback]
 
     ActiveRecord::Base.extend(Kasket::ConfigurationMixin)
     ActiveRecord::Relation.include(Kasket::RelationMixin)

--- a/lib/kasket.rb
+++ b/lib/kasket.rb
@@ -14,6 +14,7 @@ module Kasket
   autoload :Visitor,                'kasket/visitor'
   autoload :SelectManagerMixin,     'kasket/select_manager_mixin'
   autoload :RelationMixin,          'kasket/relation_mixin'
+  autoload :Events,                 'kasket/events'
 
   CONFIGURATION = { # rubocop:disable Style/MutableConstant
     max_collection_size: 100,

--- a/lib/kasket/events.rb
+++ b/lib/kasket/events.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Kasket
+  # Interface to the internal instrumentation event.
+  module Events
+    class << self
+      # Invokes the configured events callback, if provided.
+      #
+      # The callback behaves like a listener, and receives the same arguments
+      # that are passed to this `report` method.
+      #
+      # @param [String] event the type of event being instrumented.
+      # @param [class] ar_klass the ActiveRecord::Base subclass that the event
+      #   refers to.
+      #
+      # @return [nil]
+      #
+      def report(event, ar_klass)
+        return unless fn
+
+        fn.call(event, ar_klass)
+        nil
+      end
+
+      private
+
+      def fn
+        return @fn if defined?(@fn)
+
+        @fn = Kasket::CONFIGURATION[:events_callback]
+      end
+    end
+  end
+end

--- a/lib/kasket/version.rb
+++ b/lib/kasket/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Kasket
-  VERSION = '4.13.0'
+  VERSION = '4.14.0'
   class Version
     MAJOR = Kasket::VERSION.split('.')[0]
     MINOR = Kasket::VERSION.split('.')[1]

--- a/test/events_test.rb
+++ b/test/events_test.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require_relative "helper"
+
+describe Kasket::Events do
+  before do
+    @previous = Kasket::CONFIGURATION[:events_callback]
+    Kasket::Events.remove_instance_variable(:@fn) if Kasket::Events.instance_variable_defined?(:@fn)
+  end
+
+  after { Kasket::CONFIGURATION[:events_callback] = @previous }
+
+  describe "::report" do
+    describe "when there is no stats callback configured" do
+      before do
+        Kasket::CONFIGURATION[:events_callback] = nil
+      end
+
+      it "does nothing and returns safely" do
+        assert_nil Kasket::Events.report("something", Author)
+      end
+    end
+
+    describe "when a stats callback is configured" do
+      before do
+        @event = nil
+        @ar_klass = nil
+
+        callback = proc do |event, ar_klass|
+          @event = event
+          @ar_klass = ar_klass
+        end
+
+        Kasket::CONFIGURATION[:events_callback] = callback
+      end
+
+      it "returns safely" do
+        assert_nil Kasket::Events.report("something", Author)
+      end
+
+      it "invokes the callback" do
+        assert_nil @event
+        assert_nil @ar_klass
+
+        Kasket::Events.report("something", Author)
+
+        assert_equal "something", @event
+        assert_equal Author, @ar_klass
+      end
+    end
+  end
+end

--- a/test/events_test.rb
+++ b/test/events_test.rb
@@ -10,7 +10,7 @@ describe Kasket::Events do
 
   after { Kasket::CONFIGURATION[:events_callback] = @previous }
 
-  describe "::report" do
+  describe ".report" do
     describe "when there is no stats callback configured" do
       before do
         Kasket::CONFIGURATION[:events_callback] = nil


### PR DESCRIPTION
This PR introduces a new `Kasket.setup()` option to register a callback that can receive events. Only one event is introduced for now: `cache_hit`.