### PR TITLE
MODERN Ensure inverse associations can be set for Kasket cache hits

### DIFF
--- a/test/cacheable_test.rb
+++ b/test/cacheable_test.rb
@@ -4,7 +4,7 @@ require_relative "helper"
 describe "cacheable" do
   describe "#store_in_kasket" do
     it "only cache object that are kasket_cacheable?" do
-      post = Post.send(:instantiate, 'id' => 1, 'title' => 'Hello')
+      post = Post.instantiate('id' => 1, 'title' => 'Hello')
 
       post.expects(:kasket_cacheable?).returns(true)
       Kasket.cache.expects(:write).once
@@ -19,11 +19,11 @@ describe "cacheable" do
   describe "caching of results of find" do
     before do
       @post_database_result = { 'id' => 1, 'title' => 'Hello' }
-      @post_records = [Post.send(:instantiate, @post_database_result)]
+      @post_records = [Post.instantiate(@post_database_result)]
       Post.stubs(:find_by_sql_without_kasket).returns(@post_records)
 
       @comment_database_result = [{ 'id' => 1, 'body' => 'Hello' }, { 'id' => 2, 'body' => 'World' }]
-      @comment_records = @comment_database_result.map {|r| Comment.send(:instantiate, r)}
+      @comment_records = @comment_database_result.map { |r| Comment.instantiate(r) }
       Comment.stubs(:find_by_sql_without_kasket).returns(@comment_records)
     end
 

--- a/test/fixtures/comments.yml
+++ b/test/fixtures/comments.yml
@@ -10,7 +10,6 @@ few_comments_2:
 
 <% (1..10).each do |i| %>
 many_comments_<%= i %>:
-  post: has_many_comments
+  post_id: 4
   body: what ever body <%= i %>
 <% end %>
-

--- a/test/test_models.rb
+++ b/test/test_models.rb
@@ -12,6 +12,7 @@ class Comment < ActiveRecord::Base
   has_one :author, through: :post
 
   has_kasket_on :post_id
+  has_kasket_on :post_id, :id
 end
 
 class Author < ActiveRecord::Base


### PR DESCRIPTION
why? When Rails loads `post.comments.find(comment_id)` from the DB it will automatically populate the inverse associations via a passed &block to `find_by_sql` which is in turn passed to `instantiate` (https://github.com/rails/rails/blob/v6.0.6.1/activerecord/lib/active_record/association_relation.rb#L37)

Kasket was not passing the &block to instantiate. This has two side-effects:
1. The inverse record needed to be fetched from the DB/Cache again
2. Created a new instance of the inverse record which leads to strange behaviours e.g.:

```
  comment = post.comment.find(comment_id)
  ...
  comment.post.build_comment(...) # new comment is built on new instance of post
  ...
  post.save! # the new comment is not saved
```